### PR TITLE
Adding unary expression support in exporter visitor

### DIFF
--- a/src/FAST-Java-Tools-Tests/FASTJavaExportVisitorTest.class.st
+++ b/src/FAST-Java-Tools-Tests/FASTJavaExportVisitorTest.class.st
@@ -93,6 +93,24 @@ FASTJavaExportVisitorTest >> testVisitFASTJavaTypeName [
 ]
 
 { #category : #tests }
+FASTJavaExportVisitorTest >> testVisitFASTJavaUnaryExpression [
+
+	| nodeVar nodeInt |
+	nodeVar := builder
+		              unaryOp: '!'
+		              prefix: true
+		              expr: (builder var: 'isPrefix').
+
+	nodeInt := builder
+		              unaryOp: '++'
+		              prefix: false
+		              expr: (builder literalInt: 42).
+
+	self export: nodeVar equals: '!isPrefix'.
+	self export: nodeInt equals: '42++'
+]
+
+{ #category : #tests }
 FASTJavaExportVisitorTest >> testVisitFASTJavaVariableExpression [
 	self
 		export: (builder var: 'aVar')

--- a/src/FAST-Java-Tools-Tests/FASTJavaTestNodeBuilder.class.st
+++ b/src/FAST-Java-Tools-Tests/FASTJavaTestNodeBuilder.class.st
@@ -115,6 +115,16 @@ FASTJavaTestNodeBuilder >> type: aName [
 ]
 
 { #category : #'as yet unclassified' }
+FASTJavaTestNodeBuilder >> unaryOp: anOperator prefix: aBoolean expr: anExpr [
+
+	^ FASTJavaUnaryExpression new
+		  operator: anOperator;
+		  isPrefixedUnaryExpression: aBoolean;
+		  expression: anExpr;
+		  yourself
+]
+
+{ #category : #'as yet unclassified' }
 FASTJavaTestNodeBuilder >> var: aName [
 	^FASTJavaVariableExpression new
 		name: aName ;

--- a/src/FAST-Java-Tools/FASTJavaExportVisitor.class.st
+++ b/src/FAST-Java-Tools/FASTJavaExportVisitor.class.st
@@ -361,6 +361,18 @@ FASTJavaExportVisitor >> visitFASTJavaTypeName: aFASTJavaTypeName [
 	self noIndent: aFASTJavaTypeName name
 ]
 
+{ #category : #visiting }
+FASTJavaExportVisitor >> visitFASTJavaUnaryExpression: aFASTJavaUnaryExpression [
+
+	aFASTJavaUnaryExpression isPrefixedUnaryExpression
+		ifTrue: [ 
+			self noIndent: aFASTJavaUnaryExpression operator.
+			self visitFASTTExpression: aFASTJavaUnaryExpression ]
+		ifFalse: [ 
+			self visitFASTTExpression: aFASTJavaUnaryExpression.
+			self noIndent: aFASTJavaUnaryExpression operator ]
+]
+
 { #category : #'visiting statement' }
 FASTJavaExportVisitor >> visitFASTJavaVarDeclStatement: aFASTJavaVarDeclStatement [
 	aFASTJavaVarDeclStatement type accept: self.


### PR DESCRIPTION
Adding unary expression support in exporter visitor. 
Method is tested and prefix or suffix operators are supported.