### PR TITLE
Adding support for array access and array type expressions to export visitor

### DIFF
--- a/src/FAST-Java-Tools-Tests/FASTJavaExportVisitorTest.class.st
+++ b/src/FAST-Java-Tools-Tests/FASTJavaExportVisitorTest.class.st
@@ -22,6 +22,30 @@ FASTJavaExportVisitorTest >> setUp [
 ]
 
 { #category : #tests }
+FASTJavaExportVisitorTest >> testVisitFASTJavaArrayAccess [
+
+	| exprUni exprBi |
+	exprUni := builder array: 'testArray' accessAtIndex: 6.
+	exprBi := builder array: 'testArray' accessAtFirstDimensionIndex: 4 andSecondDimensionIndex: 2. 
+	
+	self export: exprUni equals: 'testArray[6]'.
+	self export: exprBi equals: 'testArray[4][2]'
+]
+
+{ #category : #tests }
+FASTJavaExportVisitorTest >> testVisitFASTJavaArrayTypeExpression [
+
+	| exprStr exprDouble exprBiStr |
+	exprStr := builder stringArrayType.
+	exprDouble := builder doubleArrayType.
+	exprBiStr := builder stringTwoDimensionalArrayType.
+	
+	self export: exprStr equals: 'String[]'.
+	self export: exprDouble equals: 'double[]'.
+	self export: exprBiStr equals: 'String[][]'
+]
+
+{ #category : #tests }
 FASTJavaExportVisitorTest >> testVisitFASTJavaAssignmentExpression [
 	| node |
 	node := builder assignment: 'aVar' value: (builder literalInt: 42).

--- a/src/FAST-Java-Tools-Tests/FASTJavaTestNodeBuilder.class.st
+++ b/src/FAST-Java-Tools-Tests/FASTJavaTestNodeBuilder.class.st
@@ -5,6 +5,24 @@ Class {
 }
 
 { #category : #'as yet unclassified' }
+FASTJavaTestNodeBuilder >> array: aName accessAtFirstDimensionIndex: firstInt andSecondDimensionIndex: secondInt [  
+
+	^ FASTJavaArrayAccess new
+		  array: (self array: aName accessAtIndex: firstInt); 
+		  expression: (self literalInt: secondInt);
+		  yourself
+]
+
+{ #category : #'as yet unclassified' }
+FASTJavaTestNodeBuilder >> array: aName accessAtIndex: anInt [
+
+	^ FASTJavaArrayAccess new
+		  array: (self var: aName);
+		  expression: (self literalInt: anInt);
+		  yourself
+]
+
+{ #category : #'as yet unclassified' }
 FASTJavaTestNodeBuilder >> assignment: aName value: aNode [
 	^FASTJavaAssignmentExpression new
 		variable: (self var: aName) ;
@@ -49,6 +67,13 @@ FASTJavaTestNodeBuilder >> declarator: aName init: aNode [
 		variable: (self var: aName) ;
 		expression: aNode ;
 		yourself
+]
+
+{ #category : #'as yet unclassified' }
+FASTJavaTestNodeBuilder >> doubleArrayType [
+	^ FASTJavaArrayTypeExpression new
+		  baseType: FASTJavaDoubleTypeExpression new;
+		  yourself
 ]
 
 { #category : #'as yet unclassified' }
@@ -115,6 +140,22 @@ FASTJavaTestNodeBuilder >> return: aNode [
 	^FASTJavaReturnStatement new
 		expression: aNode ;
 		yourself
+]
+
+{ #category : #'as yet unclassified' }
+FASTJavaTestNodeBuilder >> stringArrayType [
+
+	^ FASTJavaArrayTypeExpression new
+		  baseType: (FASTJavaTypeName new name: 'String');
+		  yourself
+]
+
+{ #category : #'as yet unclassified' }
+FASTJavaTestNodeBuilder >> stringTwoDimensionalArrayType [
+
+	^ FASTJavaArrayTypeExpression new
+		  baseType: self stringArrayType;
+		  yourself
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/FAST-Java-Tools/FASTJavaExportVisitor.class.st
+++ b/src/FAST-Java-Tools/FASTJavaExportVisitor.class.st
@@ -70,6 +70,20 @@ FASTJavaExportVisitor >> visitFASTJavaAnnotation: aFASTJavaAnnotation [
 	aFASTJavaAnnotation expression accept: self
 ]
 
+{ #category : #visiting }
+FASTJavaExportVisitor >> visitFASTJavaArrayAccess: aFASTJavaArrayAccess [
+	aFASTJavaArrayAccess array accept: self.
+	self noIndent: '['.
+	aFASTJavaArrayAccess expression accept: self.
+	self noIndent: ']'.
+]
+
+{ #category : #visiting }
+FASTJavaExportVisitor >> visitFASTJavaArrayTypeExpression: aFASTJavaArrayTypeExpression [
+	aFASTJavaArrayTypeExpression baseType accept: self.
+	self noIndent: '[]'.
+]
+
 { #category : #'visiting expression' }
 FASTJavaExportVisitor >> visitFASTJavaAssignmentExpression: aFASTJavaAssignmentExpression [
 	aFASTJavaAssignmentExpression variable accept: self.


### PR DESCRIPTION
Export visitor can now generate FASTJavaArrayAccess and FASTJavaArrayTypeExpression nodes.
Single and multi-dimensional arrays are supported and tested.