### PR TITLE
Fix #155: Correctly export FASTJavaTypeParameterExpression with multiple types

### DIFF
--- a/src/FAST-Java-Tools-Tests/FASTJavaExportVisitorTest.class.st
+++ b/src/FAST-Java-Tools-Tests/FASTJavaExportVisitorTest.class.st
@@ -1183,6 +1183,17 @@ FASTJavaExportVisitorTest >> testVisitFASTJavaTypeParameterWildCard [
 '
 ]
 
+{ #category : #tests }
+FASTJavaExportVisitorTest >> testVisitFASTJavaTypeParameterWithMultipleTypes [
+
+	| expr |
+	expr := self methodAST: '<T extends MyClass & Iterable> T mth() { }'.
+
+	self export: expr equals: '<T extends MyClass & Iterable> T mth() {
+}
+'
+]
+
 { #category : #'test from source code' }
 FASTJavaExportVisitorTest >> testVisitFASTJavaTypeParameterWithParametersExtendingSomeType [
 	

--- a/src/FAST-Java-Tools/FASTJavaExportVisitor.class.st
+++ b/src/FAST-Java-Tools/FASTJavaExportVisitor.class.st
@@ -1177,7 +1177,9 @@ FASTJavaExportVisitor >> visitFASTJavaTypeParameter: aFASTJavaTypeParameterExpre
 		self unindented: aFASTJavaTypeParameterExpression name.
 		aFASTJavaTypeParameterExpression types ifNotEmpty: [ :typeArgumentSuperclasses |
 			self unindented: ' extends '.
-			self visitNodeListSeparatedByCommas: typeArgumentSuperclasses
+			typeArgumentSuperclasses
+				do: [ :node | node accept: self ]
+				separatedBy: [ self unindented: ' & ' ]
 		]
 	]
 ]


### PR DESCRIPTION
Also see https://github.com/moosetechnology/FAST-JAVA/issues/155#issuecomment-1867747962:
> In fact, it is possible to bind a type parameter to multiple types:
> 
> ```java
> class MyClass<T extends A & B> { }
> ```
> 
> However, B (and subsequent types) **must** be an interface, but I'm not sure we want to represent that constraint.

