### PR TITLE
Parameterized/able types are deprecated since moosetechnology/Famix#635

### DIFF
--- a/src/FAST-Java-SmaCC-Importer/FamixJavaParameterizedType.extension.st
+++ b/src/FAST-Java-SmaCC-Importer/FamixJavaParameterizedType.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #FamixJavaParameterizedType }
-
-{ #category : #'*FAST-Java-SmaCC-Importer' }
-FamixJavaParameterizedType >> generateFastIfNotDoneAndBind [
-	^ self parameterizableClass generateFastIfNotDoneAndBind
-]

--- a/src/FAST-Java-SmaCC-Importer/FamixTParameterizedType.extension.st
+++ b/src/FAST-Java-SmaCC-Importer/FamixTParameterizedType.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : #FamixTParameterizedType }
-
-{ #category : #'*FAST-Java-SmaCC-Importer' }
-FamixTParameterizedType >> generateFastIfNotDoneAndBind [
-	^ self parameterizableClass generateFastIfNotDoneAndBind
-]


### PR DESCRIPTION
A parameterized type would always point to its parameterizable type directly, so there was a clear mirror-like representation and we knew where to look for relevant information, especially the source anchor.

With the change, Parametric classes represent the two sides of the coin themselves: they can be generic or concrete.
Also, a class can *concretize* a generic class and still be generic itself, so we have a tree of concretization with the root entity holding the relevant information.
This makes it difficult* to redefine `generateFastIfNotDoneAndBind` to include the root logic, instead it should be called on the `rootGenericEntity`.
*relatively speaking: it's totally doable, but not convenient and it would not make for pretty code, because the tree root and nodes have the same class...
```st
parametricClass rootGenericEntity generateFastIfNotDoneAndBind.
```