### PR TITLE
Fix #223 + Replacing FASTTLiteral trait by the FASTTBooleanLiteral trait in class FASTJavaBooleanLiteral

### DIFF
--- a/src/FAST-Java-Model-Generator/FASTJavaMetamodelGenerator.class.st
+++ b/src/FAST-Java-Model-Generator/FASTJavaMetamodelGenerator.class.st
@@ -852,7 +852,7 @@ FASTJavaMetamodelGenerator >> defineHierarchy [
 	javaIntegerLiteral --|> javaLiteral.
 	javaFloatLiteral --|> tLiteral.
 	javaFloatLiteral --|> javaLiteral.
-	javaBooleanLiteral --|> tLiteral.
+	javaBooleanLiteral --|> tBooleanLiteral.
 	javaBooleanLiteral --|> javaLiteral.
 	javaLongLiteral --|> tLiteral.
 	javaLongLiteral --|> javaLiteral.

--- a/src/FAST-Java-Model/FASTJavaBooleanLiteral.class.st
+++ b/src/FAST-Java-Model/FASTJavaBooleanLiteral.class.st
@@ -56,8 +56,8 @@ I represent a boolean literal node.
 Class {
 	#name : #FASTJavaBooleanLiteral,
 	#superclass : #FASTJavaLiteral,
-	#traits : 'FASTTLiteral',
-	#classTraits : 'FASTTLiteral classTrait',
+	#traits : 'FASTTBooleanLiteral',
+	#classTraits : 'FASTTBooleanLiteral classTrait',
 	#category : #'FAST-Java-Model-Entities'
 }
 

--- a/src/FAST-Java-Visitor/FASTJavaBooleanLiteral.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaBooleanLiteral.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #FASTJavaBooleanLiteral }
+
+{ #category : #'*FAST-Java-Visitor' }
+FASTJavaBooleanLiteral >> accept: aVisitor [
+	^ aVisitor visitFASTJavaBooleanLiteral: self
+]

--- a/src/FAST-Java-Visitor/FASTJavaDoubleLiteral.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaDoubleLiteral.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #FASTJavaDoubleLiteral }
+
+{ #category : #'*FAST-Java-Visitor' }
+FASTJavaDoubleLiteral >> accept: aVisitor [
+	^ aVisitor visitFASTJavaDoubleLiteral: self
+]

--- a/src/FAST-Java-Visitor/FASTJavaVisitor.class.st
+++ b/src/FAST-Java-Visitor/FASTJavaVisitor.class.st
@@ -45,6 +45,11 @@ FASTJavaVisitor >> visitFASTJavaBodyStatement: aFASTJavaBodyStatement [
 ]
 
 { #category : #generated }
+FASTJavaVisitor >> visitFASTJavaBooleanLiteral: aFASTJavaBooleanLiteral [
+	^ self visitFASTTBooleanLiteral: aFASTJavaBooleanLiteral
+]
+
+{ #category : #generated }
 FASTJavaVisitor >> visitFASTJavaBooleanTypeExpression: aFASTJavaBooleanTypeExpression [
 	^ self visitFASTJavaPrimitiveTypeExpression: aFASTJavaBooleanTypeExpression
 ]
@@ -133,6 +138,11 @@ FASTJavaVisitor >> visitFASTJavaDefaultCaseStatement: aFASTJavaDefaultCaseStatem
 { #category : #generated }
 FASTJavaVisitor >> visitFASTJavaDoWhileStatement: aFASTJavaDoWhileStatement [
 	^ self visitFASTTStatement: aFASTJavaDoWhileStatement
+]
+
+{ #category : #generated }
+FASTJavaVisitor >> visitFASTJavaDoubleLiteral: aFASTJavaDoubleLiteral [
+	^ self visitFASTTLiteral: aFASTJavaDoubleLiteral
 ]
 
 { #category : #generated }


### PR DESCRIPTION
This PR adds specific `accept:` messages for the classes `FASTJavaBooleanLiteral` and `FASTJavaDoubleLiteral` so that they have the same behaviour than other literal classes when a visitor is used.

Additionally, while fixing this I saw that the class `FASTJavaBooleanLiteral` uses the trait `FASTTLiteral` while the more specific `FASTTBooleanLiteral` trait exists. I changed the trait used both in the model class and the generator. 