### PR TITLE
Add TypePattern entity with SmaCC support

### DIFF
--- a/src/FAST-Java-Model-Generator/FASTJavaMetamodelGenerator.class.st
+++ b/src/FAST-Java-Model-Generator/FASTJavaMetamodelGenerator.class.st
@@ -127,7 +127,8 @@ Class {
 		'javaEnumConstant',
 		'tAnnotationElement',
 		'javaLiteral',
-		'javaArrayAnnotationElement'
+		'javaArrayAnnotationElement',
+		'javaTypePattern'
 	],
 	#category : #'FAST-Java-Model-Generator'
 }
@@ -644,6 +645,21 @@ void tryCatch() {
 ]
 
 { #category : #comments }
+FASTJavaMetamodelGenerator >> commentForJavaTypePattern [
+
+	^ 'This code element defines a type pattern, introduced in Java 16 by [JEP 394](https://openjdk.java.net/jeps/394).
+Example:
+```language=text
+	Object obj = null;
+	boolean longerThanTwo = false;
+	// String s is the type pattern, declaring a local variable
+	if (obj instanceof String s) {
+		longerThanTwo = s.length() > 2;
+	}
+```'
+]
+
+{ #category : #comments }
 FASTJavaMetamodelGenerator >> commentForJavaUnaryExpression [
 	^ 'I represent a Java Unary Expression
 	
@@ -764,6 +780,7 @@ FASTJavaMetamodelGenerator >> defineClasses [
 	javaEmptyDimExpression := builder newClassNamed: #EmptyDimExpression comment: self commentForJavaEmptyDimExpression.
 	javaAnnotationExpression := builder newClassNamed: #Annotation comment: self commentForJavaAnnotation.
 	javaArrayAnnotationElement := builder newClassNamed: #ArrayAnnotationElement comment: 'I represent an array as argument of an annotationExpression'.
+	javaTypePattern := builder newClassNamed: #TypePattern comment: self commentForJavaTypePattern.
 
 	"statements"
 	javaStatement := builder newClassNamed: #Statement.
@@ -801,7 +818,6 @@ FASTJavaMetamodelGenerator >> defineClasses [
 
 { #category : #definition }
 FASTJavaMetamodelGenerator >> defineHierarchy [
-
 	"define class hierarchy"
 
 	super defineHierarchy.
@@ -836,10 +852,10 @@ FASTJavaMetamodelGenerator >> defineHierarchy [
 	javaIfStatement --|> tStatement.
 
 	javaArrayAnnotationElement --|> tAnnotationElement.
-	javaArrayAnnotationElement --|> tExpression.  "because annotationElement=value are modeled as assignement expression"
+	javaArrayAnnotationElement --|> tExpression. "because annotationElement=value are modeled as assignement expression"
 
 	"javaLiteral  --|> tLiteral. // we use the specific tLiteral for each case"
-	javaLiteral  --|> tReceiver.
+	javaLiteral --|> tReceiver.
 	javaLiteral --|> tAnnotationElement.
 
 	javaNullLiteral --|> tNullPointerLiteral.
@@ -1010,6 +1026,8 @@ FASTJavaMetamodelGenerator >> defineHierarchy [
 	qualifiedName --|> tEntity.
 	qualifiedName --|> tAssignable.
 
+	javaTypePattern --|> tExpression.
+
 	compilationUnit --|> tEntity.
 
 	"package and import do not use TDeclaration on purpose: they are only contained in a compilation unit"
@@ -1070,10 +1088,10 @@ FASTJavaMetamodelGenerator >> defineRelations [
 			 'The owner of the expression').
 
 	((javaAnnotationExpression property: #elements) comment:
-		'"Arguments" of the annotation, eg. this @Author annotation has two annotation elements:
+		 '"Arguments" of the annotation, eg. this @Author annotation has two annotation elements:
 	@Author(name="Benjamin Franklin", date="3/27/2003")')
-		<>-* ((tAnnotationElement property: #parentAnnotation) comment:
-			'An "argument" of an annotation, eg. "unchecked" in the following annotation:
+	<>-* ((tAnnotationElement property: #parentAnnotation) comment:
+			 'An "argument" of an annotation, eg. "unchecked" in the following annotation:
 	@SuppressWarnings(value="unchecked")').
 
 	((javaArrayAnnotationElement property: #values) comment:
@@ -1089,17 +1107,16 @@ FASTJavaMetamodelGenerator >> defineRelations [
 	((javaSwitchStatement property: #cases) comment:
 		 'The cases of the switch statement')
 	<>-*
-		((javaCaseStatement property: #javaCaseStatementSwitchOwner) 
+		((javaCaseStatement property: #javaCaseStatementSwitchOwner)
 			 comment: 'The switch owner').
 
 	((javaVariableDeclarator property: #expression) comment:
 		 'Expression to be assigned to the var during declaration')
-	<>- ((tExpression property: #javaVariableDeclaratorExpressionOwner) 
+	<>- ((tExpression property: #javaVariableDeclaratorExpressionOwner)
 			 comment: 'The javaVariableDeclarator owner (if possible)').
 	((javaVariableDeclarator property: #variable) comment:
 		 'The variable that is being declared')
-	<>-
-		((javaVariableExpression property: #javaVariableDeclaratorOwner) 
+	<>- ((javaVariableExpression property: #javaVariableDeclaratorOwner)
 			 comment: 'The javaVariableDeclarator owner (if possible)').
 
 	((javaAssignmentExpression property: #expression) comment:
@@ -1113,14 +1130,13 @@ FASTJavaMetamodelGenerator >> defineRelations [
 			 'The javaCastExpression owner (if possible)').
 	((javaCastExpression property: #type) comment:
 		 'The type into which the expression will be cast')
-	<>-
-		((javaVariableExpression property: #javaCastExpressionTypeOwner) 
+	<>- ((javaVariableExpression property: #javaCastExpressionTypeOwner)
 			 comment: 'The javaCastExpression owner (if possible)').
 
 	((javaClassProperty property: #type) comment:
 		 'The type of the property')
 	<>-
-		((javaVariableExpression property: #javaClassPropertyOwner) 
+		((javaVariableExpression property: #javaClassPropertyOwner)
 			 comment: 'The javaClassProperty owner (if possible)').
 
 	((javaUnaryExpression property: #expression) comment:
@@ -1130,7 +1146,7 @@ FASTJavaMetamodelGenerator >> defineRelations [
 
 	((javaNewExpression property: #type) comment: 'The type of the array')
 	<>-
-		((javaVariableExpression property: #javaNewExpressionOwner) 
+		((javaVariableExpression property: #javaNewExpressionOwner)
 			 comment: 'The javaNewExpression owner (if possible)').
 
 	((javaArrayAccess property: #expression) comment:
@@ -1165,11 +1181,11 @@ FASTJavaMetamodelGenerator >> defineRelations [
 			 'The javaForEachStatement owner (if possible)').
 	((javaForEachStatement property: #fieldname) comment:
 		 'The identifier of the created local variable')
-	<>- ((javaIdentifier property: #javaForEachStatementFieldNameOwner) 
+	<>- ((javaIdentifier property: #javaForEachStatementFieldNameOwner)
 			 comment: 'The javaForEachStatement owner (if possible)').
 	((javaForEachStatement property: #type) comment:
 		 'The type of the created local variable')
-	<>- ((javaTypeExpression property: #javaForEachStatementTypeOwner) 
+	<>- ((javaTypeExpression property: #javaForEachStatementTypeOwner)
 			 comment: 'The javaForEachStatement owner (if possible)').
 
 	((javaTryCatchStatement property: #try) comment:
@@ -1187,20 +1203,22 @@ FASTJavaMetamodelGenerator >> defineRelations [
 
 	((javaCatchPartStatement property: #body) comment:
 		 'The body of the catch part')
-	<>- ((javaStatementBlock property: #javaCatchPartStatementOwner) comment:
-			 'The javaCatchPartStatementOwner owner (if possible)').
+	<>-
+		((javaStatementBlock property: #javaCatchPartStatementOwner)
+			 comment: 'The javaCatchPartStatementOwner owner (if possible)').
 	((javaTryCatchStatement property: #resources) comment:
 		 'I contain the resources in a try-with-resource statement')
-	<>-* ((javaVarDeclStatement property: #javaTryResourceOwner) comment:
+	<>-*
+		((javaVarDeclStatement property: #javaTryResourceOwner) comment:
 			 'The try-with-resource that owns me').
 
 	((javaCatchPartStatement property: #catchedTypes) comment:
-			 'The types (exception) that are catched')
+		 'The types (exception) that are catched')
 	<>-* ((javaTypeExpression property: #catchOwner) comment:
 			 'The catch part that owns me (ie. where I am catched)').
 	((javaCatchPartStatement property: #parameter) comment:
 		 'The parameter of the catch part')
-	<>- ((javaVariableExpression property: #javaCatchParameterOwnler) 
+	<>- ((javaVariableExpression property: #javaCatchParameterOwnler)
 			 comment: 'The javaCatchPartParameterOwner owner (if possible)').
 
 	((javaIfStatement property: #condition) comment:
@@ -1296,7 +1314,7 @@ FASTJavaMetamodelGenerator >> defineRelations [
 
 	((javaMethodReference property: #receiver) comment:
 		 'The method of the reference')
-	<>- ((javaVariableExpression property: #javaMethodReferenceOwner) 
+	<>- ((javaVariableExpression property: #javaMethodReferenceOwner)
 			 comment: 'The owner of the method reference (if possible)').
 
 	((javaSynchronizedStatement property: #expression) comment:
@@ -1307,7 +1325,7 @@ FASTJavaMetamodelGenerator >> defineRelations [
 	((javaSynchronizedStatement property: #block) comment:
 		 'The block that is synchronized')
 	<>-
-		((tStatementBlock property: #javaSynchronizedStatementOwner) 
+		((tStatementBlock property: #javaSynchronizedStatementOwner)
 			 comment: 'The owner of the synchronized block (if possible)').
 
 	((javaMethodEntity property: #type) comment: 'The type of the method')
@@ -1317,12 +1335,12 @@ FASTJavaMetamodelGenerator >> defineRelations [
 	((javaMethodEntity property: #throws) comment:
 		 'The list of throws exception')
 	<>-*
-		((javaClassTypeExpression property: #javaMethodThrowsOwner) 
+		((javaClassTypeExpression property: #javaMethodThrowsOwner)
 			 comment: 'The method that throws me').
 	((javaMethodEntity property: #typeParameters) comment:
 		 'The list of type parameter')
 	<>-*
-		((javaTypeParameter property: #javaMethodTypeParameterOwner) 
+		((javaTypeParameter property: #javaMethodTypeParameterOwner)
 			 comment: 'The method that use me').
 
 	((javaTypeParameter property: #types) comment:
@@ -1334,11 +1352,11 @@ FASTJavaMetamodelGenerator >> defineRelations [
 	((javaParameterExpression property: #type) comment:
 		 'The type of the parameter')
 	<>-
-		((javaVariableExpression property: #javaParameterTypeOwner) 
+		((javaVariableExpression property: #javaParameterTypeOwner)
 			 comment: 'The variable expression owner (if possible)').
 	((javaParameterExpression property: #variable) comment:
 		 'parameter variable')
-	<>- ((javaVariableExpression property: #javaParameterVariableOwner) 
+	<>- ((javaVariableExpression property: #javaParameterVariableOwner)
 			 comment: 'The variable expression owner (if possible)').
 
 	((javaVarDeclStatement property: #type) comment:
@@ -1369,31 +1387,31 @@ FASTJavaMetamodelGenerator >> defineRelations [
 			 'I represent a condition for my owner').
 	((javaAssertStatement property: #message) comment:
 		 'The error message that is raised if the condition is false')
-	<>- ((tExpression property: #javaStringAssertStatementOwner) 
-			 comment: 'The assertion which I describe').
+	<>-
+		((tExpression property: #javaStringAssertStatementOwner) comment:
+			 'The assertion which I describe').
 
 	((javaClassDeclaration property: #superclass) comment:
 		 'My superclass')
 	<>-
-		((javaTypeExpression property: #javaClassDeclarationSuperclassOwner) 
+		((javaTypeExpression property: #javaClassDeclarationSuperclassOwner)
 			 comment: 'The class that extends me').
 	((javaClassDeclaration property: #interfaces) comment:
 		 'The interfaces I implement')
 	<>-*
-		((javaTypeExpression property: #javaClassDeclarationInterfaceOwner) 
+		((javaTypeExpression property: #javaClassDeclarationInterfaceOwner)
 			 comment: 'The class that implements me').
 
 	((javaEnumDeclaration property: #interfaces) comment:
 		 'The interfaces I implement')
 	<>-*
-		((javaTypeExpression property: #javaEnumDeclarationInterfaceOwner) 
+		((javaTypeExpression property: #javaEnumDeclarationInterfaceOwner)
 			 comment: 'The enum that implements me').
 
 	((javaEnumDeclaration property: #constants) comment:
 		 'The constants I define')
-	<>-*
-		((javaEnumConstant property: #parentEnum) 
-			 comment: 'The enum type that contains me').
+	<>-* ((javaEnumConstant property: #parentEnum) comment:
+			 'The enum type that contains me').
 
 	((javaInterfaceDeclaration property: #interfaces) comment:
 		 'My super interfaces')
@@ -1428,6 +1446,17 @@ FASTJavaMetamodelGenerator >> defineRelations [
 		 'The name that qualifies me')
 	<>- ((qualifiedName property: #qualifiedNameOwner) comment:
 			 'The owner of the qualified name').
+
+	"a type pattern declares a single variable"
+	((javaTypePattern property: #variable) comment:
+		 'The local variable declared by this type pattern')
+	<>-
+		((javaVariableExpression property: #javaTypePatternVariableOwner)
+			 comment: 'The javaTypePattern variable owner (if possible)').
+	((javaTypePattern property: #type) comment:
+		 'The type of the declared variable')
+	<>- ((javaVariableExpression property: #javaTypePatternTypeOwner)
+			 comment: 'The javaTypePattern type owner (if possible)').
 
 	"do not use TDeclaration and TWithDeclaration on purpose: what a compilation unit can contain is strict"
 	((compilationUnit property: #packageDeclaration) comment:

--- a/src/FAST-Java-Model-Generator/FASTJavaMetamodelGenerator.class.st
+++ b/src/FAST-Java-Model-Generator/FASTJavaMetamodelGenerator.class.st
@@ -1455,8 +1455,9 @@ FASTJavaMetamodelGenerator >> defineRelations [
 			 comment: 'The javaTypePattern variable owner (if possible)').
 	((javaTypePattern property: #type) comment:
 		 'The type of the declared variable')
-	<>- ((javaVariableExpression property: #javaTypePatternTypeOwner)
-			 comment: 'The javaTypePattern type owner (if possible)').
+	<>-
+		((javaTypeExpression property: #javaTypePatternTypeOwner) comment:
+			 'The javaTypePattern type owner (if possible)').
 
 	"do not use TDeclaration and TWithDeclaration on purpose: what a compilation unit can contain is strict"
 	((compilationUnit property: #packageDeclaration) comment:

--- a/src/FAST-Java-Model/FASTJavaAnnotation.class.st
+++ b/src/FAST-Java-Model/FASTJavaAnnotation.class.st
@@ -12,21 +12,15 @@ example:
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `arrayOwner` | `FASTJavaTAnnotationElement` | `values` | `FASTJavaArrayAnnotationElement` | The ArrayAnnotationElement I am an element of|
+| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 | `javaLambdaExpressionOwner` | `FASTTEntity` | `expression` | `FASTJavaLambdaExpression` | The expression owner (if possible)|
 | `javaModifierOwner` | `FASTJavaTModifier` | `modifiers` | `FASTJavaTWithModifiers` | The owner of the modifier|
-| `parentAnnotation` | `FASTJavaTAnnotationElement` | `elements` | `FASTJavaAnnotation` | An ""argument"" of an annotation, eg. ""unchecked"" in the following annotation:
-	@SuppressWarnings(value=""unchecked"")|
+| `parentAnnotation` | `FASTJavaTAnnotationElement` | `elements` | `FASTJavaAnnotation` | An ""argument"" of an annotation, eg. ""unchecked"" in the following annotation: 	@SuppressWarnings(value=""unchecked"")|
 
 ### Children
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `elements` | `FASTJavaAnnotation` | `parentAnnotation` | `FASTJavaTAnnotationElement` | ""Arguments"" of the annotation, eg. this @Author annotation has two annotation elements:
-	@Author(name=""Benjamin Franklin"", date=""3/27/2003"")|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
+| `elements` | `FASTJavaAnnotation` | `parentAnnotation` | `FASTJavaTAnnotationElement` | ""Arguments"" of the annotation, eg. this @Author annotation has two annotation elements: 	@Author(name=""Benjamin Franklin"", date=""3/27/2003"")|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaArrayAccess.class.st
+++ b/src/FAST-Java-Model/FASTJavaArrayAccess.class.st
@@ -13,6 +13,7 @@ liste[i]
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -38,6 +39,9 @@ liste[i]
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableAssignmentOwner` | `FASTJavaTAssignable` | `variable` | `FASTJavaTWithAssignable` | The owner of the assignment|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `receiverOwner` | `FASTJavaTReceiver` | `receiver` | `FASTJavaTWithReceiver` | The owner of the receiver|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
@@ -48,11 +52,6 @@ liste[i]
 |---|
 | `array` | `FASTJavaArrayAccess` | `javaArrayArrayAccessOwner` | `FASTTExpression` | Name of accessed field|
 | `expression` | `FASTJavaArrayAccess` | `javaArrayAccessOwner` | `FASTTExpression` | The accessed index|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaArrayAnnotationElement.class.st
+++ b/src/FAST-Java-Model/FASTJavaArrayAnnotationElement.class.st
@@ -10,6 +10,7 @@ I represent an array as argument of an annotationExpression
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `arrayOwner` | `FASTJavaTAnnotationElement` | `values` | `FASTJavaArrayAnnotationElement` | The ArrayAnnotationElement I am an element of|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -34,8 +35,10 @@ I represent an array as argument of an annotationExpression
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
-| `parentAnnotation` | `FASTJavaTAnnotationElement` | `elements` | `FASTJavaAnnotation` | An ""argument"" of an annotation, eg. ""unchecked"" in the following annotation:
-	@SuppressWarnings(value=""unchecked"")|
+| `parentAnnotation` | `FASTJavaTAnnotationElement` | `elements` | `FASTJavaAnnotation` | An ""argument"" of an annotation, eg. ""unchecked"" in the following annotation: 	@SuppressWarnings(value=""unchecked"")|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
@@ -44,11 +47,6 @@ I represent an array as argument of an annotationExpression
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `values` | `FASTJavaArrayAnnotationElement` | `arrayOwner` | `FASTJavaTAnnotationElement` | Annotation elements in the Array|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaArrayInitializer.class.st
+++ b/src/FAST-Java-Model/FASTJavaArrayInitializer.class.st
@@ -19,6 +19,7 @@ My initializers are
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `arrayOwner` | `FASTJavaTAnnotationElement` | `values` | `FASTJavaArrayAnnotationElement` | The ArrayAnnotationElement I am an element of|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -43,8 +44,10 @@ My initializers are
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
-| `parentAnnotation` | `FASTJavaTAnnotationElement` | `elements` | `FASTJavaAnnotation` | An ""argument"" of an annotation, eg. ""unchecked"" in the following annotation:
-	@SuppressWarnings(value=""unchecked"")|
+| `parentAnnotation` | `FASTJavaTAnnotationElement` | `elements` | `FASTJavaAnnotation` | An ""argument"" of an annotation, eg. ""unchecked"" in the following annotation: 	@SuppressWarnings(value=""unchecked"")|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
@@ -53,11 +56,6 @@ My initializers are
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `initializers` | `FASTJavaArrayInitializer` | `javaArrayInitializers` | `FASTTExpression` | My initializers|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaAssignmentExpression.class.st
+++ b/src/FAST-Java-Model/FASTJavaAssignmentExpression.class.st
@@ -12,6 +12,7 @@ Contains a referances to an assignee assignee and the expression that's being as
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `arrayOwner` | `FASTJavaTAnnotationElement` | `values` | `FASTJavaArrayAnnotationElement` | The ArrayAnnotationElement I am an element of|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -36,8 +37,10 @@ Contains a referances to an assignee assignee and the expression that's being as
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
-| `parentAnnotation` | `FASTJavaTAnnotationElement` | `elements` | `FASTJavaAnnotation` | An ""argument"" of an annotation, eg. ""unchecked"" in the following annotation:
-	@SuppressWarnings(value=""unchecked"")|
+| `parentAnnotation` | `FASTJavaTAnnotationElement` | `elements` | `FASTJavaAnnotation` | An ""argument"" of an annotation, eg. ""unchecked"" in the following annotation: 	@SuppressWarnings(value=""unchecked"")|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `receiverOwner` | `FASTJavaTReceiver` | `receiver` | `FASTJavaTWithReceiver` | The owner of the receiver|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
@@ -48,11 +51,6 @@ Contains a referances to an assignee assignee and the expression that's being as
 |---|
 | `expression` | `FASTJavaAssignmentExpression` | `javaAssignmentExpressionOwner` | `FASTTExpression` | Expression to be assigned to the var during declaration|
 | `variable` | `FASTJavaTWithAssignable` | `javaVariableAssignmentOwner` | `FASTJavaTAssignable` | My variable|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaBooleanLiteral.class.st
+++ b/src/FAST-Java-Model/FASTJavaBooleanLiteral.class.st
@@ -9,6 +9,7 @@ I represent a boolean literal node.
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -33,14 +34,12 @@ I represent a boolean literal node.
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaCharacterLiteral.class.st
+++ b/src/FAST-Java-Model/FASTJavaCharacterLiteral.class.st
@@ -14,6 +14,7 @@ char c = 'a';
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -38,14 +39,12 @@ char c = 'a';
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaClassDeclaration.class.st
+++ b/src/FAST-Java-Model/FASTJavaClassDeclaration.class.st
@@ -23,6 +23,7 @@ public class ClassName extends SomeClass implements OneClass, TwoClass {
 | `forIninitializerOwner` | `FASTTStatement` | `initializer` | `FASTJavaForStatement` | I am the initializer of the for|
 | `ifElsePartOwner` | `FASTTStatement` | `elsePart` | `FASTJavaIfStatement` | The if owner (if possible)|
 | `ifThenPartOwner` | `FASTTStatement` | `thenPart` | `FASTJavaIfStatement` | The if owner (if possible)|
+| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 | `javaDeclarationOwner` | `FASTJavaTDeclaration` | `declarations` | `FASTJavaTWithDeclarations` | The element that declares me|
 | `javaForEachStatementOwner` | `FASTTStatement` | `body` | `FASTJavaForEachStatement` | The javaForEachStatement owner (if possible)|
 | `javaLambdaExpressionOwner` | `FASTTEntity` | `expression` | `FASTJavaLambdaExpression` | The expression owner (if possible)|
@@ -42,7 +43,6 @@ public class ClassName extends SomeClass implements OneClass, TwoClass {
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `element` | `FamixTSourceAnchor` | `sourceAnchor` | `FamixTSourceEntity` | Enable the accessibility to the famix entity that this class is a source pointer for|
-| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaClassProperty.class.st
+++ b/src/FAST-Java-Model/FASTJavaClassProperty.class.st
@@ -38,8 +38,7 @@ class Enclosing {
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `arrayOwner` | `FASTJavaTAnnotationElement` | `values` | `FASTJavaArrayAnnotationElement` | The ArrayAnnotationElement I am an element of|
-| `parentAnnotation` | `FASTJavaTAnnotationElement` | `elements` | `FASTJavaAnnotation` | An ""argument"" of an annotation, eg. ""unchecked"" in the following annotation:
-	@SuppressWarnings(value=""unchecked"")|
+| `parentAnnotation` | `FASTJavaTAnnotationElement` | `elements` | `FASTJavaAnnotation` | An ""argument"" of an annotation, eg. ""unchecked"" in the following annotation: 	@SuppressWarnings(value=""unchecked"")|
 | `receiverOwner` | `FASTJavaTReceiver` | `receiver` | `FASTJavaTWithReceiver` | The owner of the receiver|
 
 ### Children

--- a/src/FAST-Java-Model/FASTJavaComment.class.st
+++ b/src/FAST-Java-Model/FASTJavaComment.class.st
@@ -4,7 +4,7 @@ I represent a Java comment (block or line comment)
 ## Relations
 ======================
 
-### Other
+### Parents
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `container` | `FASTTComment` | `comments` | `FASTTWithComments` | Source code entity containing the comment|

--- a/src/FAST-Java-Model/FASTJavaConditionalExpression.class.st
+++ b/src/FAST-Java-Model/FASTJavaConditionalExpression.class.st
@@ -13,6 +13,7 @@ ex:
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -37,6 +38,9 @@ ex:
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `receiverOwner` | `FASTJavaTReceiver` | `receiver` | `FASTJavaTWithReceiver` | The owner of the receiver|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
@@ -48,11 +52,6 @@ ex:
 | `condition` | `FASTJavaConditionalExpression` | `conditionalConditionOwner` | `FASTTExpression` | The condition of the statement|
 | `elsePart` | `FASTJavaConditionalExpression` | `conditionalElsePartOwner` | `FASTTExpression` | else part|
 | `thenPart` | `FASTJavaConditionalExpression` | `conditionalThenPartOwner` | `FASTTExpression` | then part|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaDoubleLiteral.class.st
+++ b/src/FAST-Java-Model/FASTJavaDoubleLiteral.class.st
@@ -15,6 +15,7 @@ double d2 = 12.3d;
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -39,14 +40,12 @@ double d2 = 12.3d;
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaEmptyDimExpression.class.st
+++ b/src/FAST-Java-Model/FASTJavaEmptyDimExpression.class.st
@@ -11,6 +11,7 @@ A node representing an empty expression when creating an array, for example:
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -35,14 +36,12 @@ A node representing an empty expression when creating an array, for example:
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaEntity.class.st
+++ b/src/FAST-Java-Model/FASTJavaEntity.class.st
@@ -7,7 +7,7 @@
 |---|
 | `javaLambdaExpressionOwner` | `FASTTEntity` | `expression` | `FASTJavaLambdaExpression` | The expression owner (if possible)|
 
-### Other
+### Children
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `comments` | `FASTTWithComments` | `container` | `FASTTComment` | list of comments defined in the entity|

--- a/src/FAST-Java-Model/FASTJavaEnumDeclaration.class.st
+++ b/src/FAST-Java-Model/FASTJavaEnumDeclaration.class.st
@@ -25,6 +25,7 @@ public enum MyEnum {
 | `forIninitializerOwner` | `FASTTStatement` | `initializer` | `FASTJavaForStatement` | I am the initializer of the for|
 | `ifElsePartOwner` | `FASTTStatement` | `elsePart` | `FASTJavaIfStatement` | The if owner (if possible)|
 | `ifThenPartOwner` | `FASTTStatement` | `thenPart` | `FASTJavaIfStatement` | The if owner (if possible)|
+| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 | `javaDeclarationOwner` | `FASTJavaTDeclaration` | `declarations` | `FASTJavaTWithDeclarations` | The element that declares me|
 | `javaForEachStatementOwner` | `FASTTStatement` | `body` | `FASTJavaForEachStatement` | The javaForEachStatement owner (if possible)|
 | `javaLambdaExpressionOwner` | `FASTTEntity` | `expression` | `FASTJavaLambdaExpression` | The expression owner (if possible)|
@@ -44,7 +45,6 @@ public enum MyEnum {
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `element` | `FamixTSourceAnchor` | `sourceAnchor` | `FamixTSourceEntity` | Enable the accessibility to the famix entity that this class is a source pointer for|
-| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaFieldAccess.class.st
+++ b/src/FAST-Java-Model/FASTJavaFieldAccess.class.st
@@ -9,6 +9,7 @@ A FASTJavaFieldAccess corresponds to an access to an instance variable (field)
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -34,6 +35,9 @@ A FASTJavaFieldAccess corresponds to an access to an instance variable (field)
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableAssignmentOwner` | `FASTJavaTAssignable` | `variable` | `FASTJavaTWithAssignable` | The owner of the assignment|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `receiverOwner` | `FASTJavaTReceiver` | `receiver` | `FASTJavaTWithReceiver` | The owner of the receiver|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
@@ -43,11 +47,6 @@ A FASTJavaFieldAccess corresponds to an access to an instance variable (field)
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `receiver` | `FASTJavaTWithReceiver` | `receiverOwner` | `FASTJavaTReceiver` | My receiver|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaFloatLiteral.class.st
+++ b/src/FAST-Java-Model/FASTJavaFloatLiteral.class.st
@@ -14,6 +14,7 @@ float f = 12.3f;
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -38,14 +39,12 @@ float f = 12.3f;
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaInfixOperation.class.st
+++ b/src/FAST-Java-Model/FASTJavaInfixOperation.class.st
@@ -14,6 +14,7 @@ ex:
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -38,6 +39,9 @@ ex:
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `receiverOwner` | `FASTJavaTReceiver` | `receiver` | `FASTJavaTWithReceiver` | The owner of the receiver|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
@@ -48,11 +52,6 @@ ex:
 |---|
 | `leftOperand` | `FASTJavaInfixOperation` | `infixOperationLeftOperandOwner` | `FASTTExpression` | leftOperand|
 | `rightOperand` | `FASTJavaInfixOperation` | `infixOperationRightOperandOwner` | `FASTTExpression` | rightOperand|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaIntegerLiteral.class.st
+++ b/src/FAST-Java-Model/FASTJavaIntegerLiteral.class.st
@@ -9,6 +9,7 @@ I represent an integer literal node.
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -33,14 +34,12 @@ I represent an integer literal node.
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaInterfaceDeclaration.class.st
+++ b/src/FAST-Java-Model/FASTJavaInterfaceDeclaration.class.st
@@ -24,6 +24,7 @@ public interface MyInterface {
 | `forIninitializerOwner` | `FASTTStatement` | `initializer` | `FASTJavaForStatement` | I am the initializer of the for|
 | `ifElsePartOwner` | `FASTTStatement` | `elsePart` | `FASTJavaIfStatement` | The if owner (if possible)|
 | `ifThenPartOwner` | `FASTTStatement` | `thenPart` | `FASTJavaIfStatement` | The if owner (if possible)|
+| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 | `javaDeclarationOwner` | `FASTJavaTDeclaration` | `declarations` | `FASTJavaTWithDeclarations` | The element that declares me|
 | `javaForEachStatementOwner` | `FASTTStatement` | `body` | `FASTJavaForEachStatement` | The javaForEachStatement owner (if possible)|
 | `javaLambdaExpressionOwner` | `FASTTEntity` | `expression` | `FASTJavaLambdaExpression` | The expression owner (if possible)|
@@ -42,7 +43,6 @@ public interface MyInterface {
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `element` | `FamixTSourceAnchor` | `sourceAnchor` | `FamixTSourceEntity` | Enable the accessibility to the famix entity that this class is a source pointer for|
-| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaLambdaExpression.class.st
+++ b/src/FAST-Java-Model/FASTJavaLambdaExpression.class.st
@@ -9,6 +9,7 @@ I represent a lambda expression
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -33,6 +34,9 @@ I represent a lambda expression
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
@@ -42,11 +46,6 @@ I represent a lambda expression
 |---|
 | `expression` | `FASTJavaLambdaExpression` | `javaLambdaExpressionOwner` | `FASTTEntity` | Expression to be executed as part of the lambda.|
 | `parameters` | `FASTTWithParameters` | `parameterOwner` | `FASTTVariableEntity` | My parameters|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaLiteral.class.st
+++ b/src/FAST-Java-Model/FASTJavaLiteral.class.st
@@ -8,8 +8,7 @@ abtract class for all literals
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `arrayOwner` | `FASTJavaTAnnotationElement` | `values` | `FASTJavaArrayAnnotationElement` | The ArrayAnnotationElement I am an element of|
-| `parentAnnotation` | `FASTJavaTAnnotationElement` | `elements` | `FASTJavaAnnotation` | An ""argument"" of an annotation, eg. ""unchecked"" in the following annotation:
-	@SuppressWarnings(value=""unchecked"")|
+| `parentAnnotation` | `FASTJavaTAnnotationElement` | `elements` | `FASTJavaAnnotation` | An ""argument"" of an annotation, eg. ""unchecked"" in the following annotation: 	@SuppressWarnings(value=""unchecked"")|
 | `receiverOwner` | `FASTJavaTReceiver` | `receiver` | `FASTJavaTWithReceiver` | The owner of the receiver|
 
 

--- a/src/FAST-Java-Model/FASTJavaLongLiteral.class.st
+++ b/src/FAST-Java-Model/FASTJavaLongLiteral.class.st
@@ -14,6 +14,7 @@ long l = 2147483648L;
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -38,14 +39,12 @@ long l = 2147483648L;
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaMethodEntity.class.st
+++ b/src/FAST-Java-Model/FASTJavaMethodEntity.class.st
@@ -7,6 +7,7 @@ Represents a Java method
 ### Parents
 | Relation | Origin | Opposite | Type | Comment |
 |---|
+| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 | `javaDeclarationOwner` | `FASTJavaTDeclaration` | `declarations` | `FASTJavaTWithDeclarations` | The element that declares me|
 | `javaLambdaExpressionOwner` | `FASTTEntity` | `expression` | `FASTJavaLambdaExpression` | The expression owner (if possible)|
 
@@ -24,7 +25,6 @@ Represents a Java method
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `element` | `FamixTSourceAnchor` | `sourceAnchor` | `FamixTSourceEntity` | Enable the accessibility to the famix entity that this class is a source pointer for|
-| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaMethodInvocation.class.st
+++ b/src/FAST-Java-Model/FASTJavaMethodInvocation.class.st
@@ -9,6 +9,7 @@ A node representing method invocation
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -18,6 +19,7 @@ A node representing method invocation
 | `ifConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaIfStatement` | I represent a condition for my owner|
 | `infixOperationLeftOperandOwner` | `FASTTExpression` | `leftOperand` | `FASTJavaInfixOperation` | The left operand (if possible)|
 | `infixOperationRightOperandOwner` | `FASTTExpression` | `rightOperand` | `FASTJavaInfixOperation` | The right operand (if possible)|
+| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 | `javaArrayAccessOwner` | `FASTTExpression` | `expression` | `FASTJavaArrayAccess` | The javaArrayAccess owner (if possible)|
 | `javaArrayArrayAccessOwner` | `FASTTExpression` | `array` | `FASTJavaArrayAccess` | The javaArrayArrayAccess owner (if possible)|
 | `javaArrayInitializers` | `FASTTExpression` | `initializers` | `FASTJavaArrayInitializer` | The owner of the expression|
@@ -33,6 +35,9 @@ A node representing method invocation
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `receiverOwner` | `FASTJavaTReceiver` | `receiver` | `FASTJavaTWithReceiver` | The owner of the receiver|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
@@ -42,14 +47,8 @@ A node representing method invocation
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `arguments` | `FASTTWithArguments` | `argumentOwner` | `FASTTExpression` | My arguments|
-| `receiver` | `FASTJavaTWithReceiver` | `receiverOwner` | `FASTJavaTReceiver` | My receiver|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `invoked` | `FASTTInvocation` | `invokedIn` | `FASTTNamedEntity` | The name of the behavioural invoked|
-| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
+| `receiver` | `FASTJavaTWithReceiver` | `receiverOwner` | `FASTJavaTReceiver` | My receiver|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaMethodReference.class.st
+++ b/src/FAST-Java-Model/FASTJavaMethodReference.class.st
@@ -9,6 +9,7 @@ I represent a method reference
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -18,6 +19,7 @@ I represent a method reference
 | `ifConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaIfStatement` | I represent a condition for my owner|
 | `infixOperationLeftOperandOwner` | `FASTTExpression` | `leftOperand` | `FASTJavaInfixOperation` | The left operand (if possible)|
 | `infixOperationRightOperandOwner` | `FASTTExpression` | `rightOperand` | `FASTJavaInfixOperation` | The right operand (if possible)|
+| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 | `javaArrayAccessOwner` | `FASTTExpression` | `expression` | `FASTJavaArrayAccess` | The javaArrayAccess owner (if possible)|
 | `javaArrayArrayAccessOwner` | `FASTTExpression` | `array` | `FASTJavaArrayAccess` | The javaArrayArrayAccess owner (if possible)|
 | `javaArrayInitializers` | `FASTTExpression` | `initializers` | `FASTJavaArrayInitializer` | The owner of the expression|
@@ -33,6 +35,9 @@ I represent a method reference
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
@@ -41,12 +46,6 @@ I represent a method reference
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `receiver` | `FASTJavaMethodReference` | `javaMethodReferenceOwner` | `FASTJavaVariableExpression` | The method of the reference|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
-| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaModifier.class.st
+++ b/src/FAST-Java-Model/FASTJavaModifier.class.st
@@ -33,6 +33,7 @@ for methods:
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -58,14 +59,12 @@ for methods:
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaNewExpression.class.st
+++ b/src/FAST-Java-Model/FASTJavaNewExpression.class.st
@@ -13,6 +13,7 @@ new Patate()
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -37,6 +38,9 @@ new Patate()
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `receiverOwner` | `FASTJavaTReceiver` | `receiver` | `FASTJavaTWithReceiver` | The owner of the receiver|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
@@ -48,11 +52,6 @@ new Patate()
 | `arguments` | `FASTTWithArguments` | `argumentOwner` | `FASTTExpression` | My arguments|
 | `receiver` | `FASTJavaTWithReceiver` | `receiverOwner` | `FASTJavaTReceiver` | My receiver|
 | `type` | `FASTJavaNewExpression` | `javaNewExpressionOwner` | `FASTJavaVariableExpression` | The type of the array|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaNullLiteral.class.st
+++ b/src/FAST-Java-Model/FASTJavaNullLiteral.class.st
@@ -9,6 +9,7 @@ I represent a `null` literal node.
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -33,14 +34,12 @@ I represent a `null` literal node.
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaOuterThis.class.st
+++ b/src/FAST-Java-Model/FASTJavaOuterThis.class.st
@@ -13,6 +13,7 @@ hello(MyClass.this)
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -37,6 +38,9 @@ hello(MyClass.this)
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `receiverOwner` | `FASTJavaTReceiver` | `receiver` | `FASTJavaTWithReceiver` | The owner of the receiver|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
@@ -46,11 +50,6 @@ hello(MyClass.this)
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `type` | `FASTJavaOuterThis` | `javaOuterThisOwner` | `FASTJavaVariableExpression` | The accessed type|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaParameter.class.st
+++ b/src/FAST-Java-Model/FASTJavaParameter.class.st
@@ -9,6 +9,7 @@ I represent a parameter of a method declaration
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -18,6 +19,7 @@ I represent a parameter of a method declaration
 | `ifConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaIfStatement` | I represent a condition for my owner|
 | `infixOperationLeftOperandOwner` | `FASTTExpression` | `leftOperand` | `FASTJavaInfixOperation` | The left operand (if possible)|
 | `infixOperationRightOperandOwner` | `FASTTExpression` | `rightOperand` | `FASTJavaInfixOperation` | The right operand (if possible)|
+| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 | `javaArrayAccessOwner` | `FASTTExpression` | `expression` | `FASTJavaArrayAccess` | The javaArrayAccess owner (if possible)|
 | `javaArrayArrayAccessOwner` | `FASTTExpression` | `array` | `FASTJavaArrayAccess` | The javaArrayArrayAccess owner (if possible)|
 | `javaArrayInitializers` | `FASTTExpression` | `initializers` | `FASTJavaArrayInitializer` | The owner of the expression|
@@ -34,6 +36,10 @@ I represent a parameter of a method declaration
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
 | `parameterOwner` | `FASTTVariableEntity` | `parameters` | `FASTTWithParameters` | parameterOwner|
+| `parentAssignmentExpression` | `FASTTVariableEntity` | `variable` | `FASTTAssignment` | Optional assignment to the variable|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
@@ -43,13 +49,6 @@ I represent a parameter of a method declaration
 |---|
 | `type` | `FASTJavaParameter` | `javaParameterTypeOwner` | `FASTJavaVariableExpression` | The type of the parameter|
 | `variable` | `FASTJavaParameter` | `javaParameterVariableOwner` | `FASTJavaVariableExpression` | parameter variable|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
-| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
-| `parentAssignmentExpression` | `FASTTVariableEntity` | `variable` | `FASTTAssignment` | Optional assignment to the variable|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaQualifiedName.class.st
+++ b/src/FAST-Java-Model/FASTJavaQualifiedName.class.st
@@ -5,6 +5,7 @@
 ### Parents
 | Relation | Origin | Opposite | Type | Comment |
 |---|
+| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 | `javaLambdaExpressionOwner` | `FASTTEntity` | `expression` | `FASTJavaLambdaExpression` | The expression owner (if possible)|
 | `javaVariableAssignmentOwner` | `FASTJavaTAssignable` | `variable` | `FASTJavaTWithAssignable` | The owner of the assignment|
 | `namespaceOwner` | `FASTJavaQualifiedName` | `namespace` | `FASTJavaQualifiedName` | The namespace I qualify|
@@ -14,11 +15,6 @@
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `namespace` | `FASTJavaQualifiedName` | `namespaceOwner` | `FASTJavaQualifiedName` | The namespace that qualifies me|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaStringLiteral.class.st
+++ b/src/FAST-Java-Model/FASTJavaStringLiteral.class.st
@@ -9,6 +9,7 @@ I represent a string literal node.
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -33,14 +34,12 @@ I represent a string literal node.
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaTAnnotationElement.trait.st
+++ b/src/FAST-Java-Model/FASTJavaTAnnotationElement.trait.st
@@ -9,8 +9,7 @@ I can be used as an annotation ""argument"" eg: @SuppressWarnings(value=""unchec
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `arrayOwner` | `FASTJavaTAnnotationElement` | `values` | `FASTJavaArrayAnnotationElement` | The ArrayAnnotationElement I am an element of|
-| `parentAnnotation` | `FASTJavaTAnnotationElement` | `elements` | `FASTJavaAnnotation` | An ""argument"" of an annotation, eg. ""unchecked"" in the following annotation:
-	@SuppressWarnings(value=""unchecked"")|
+| `parentAnnotation` | `FASTJavaTAnnotationElement` | `elements` | `FASTJavaAnnotation` | An ""argument"" of an annotation, eg. ""unchecked"" in the following annotation: 	@SuppressWarnings(value=""unchecked"")|
 
 
 

--- a/src/FAST-Java-Model/FASTJavaTEntityCreator.trait.st
+++ b/src/FAST-Java-Model/FASTJavaTEntityCreator.trait.st
@@ -565,6 +565,13 @@ FASTJavaTEntityCreator >> newTypeParameterExpression [
 ]
 
 { #category : #'entity creation' }
+FASTJavaTEntityCreator >> newTypePattern [
+
+	<generated>
+	^ self add: FASTJavaTypePattern new
+]
+
+{ #category : #'entity creation' }
 FASTJavaTEntityCreator >> newUnaryExpression [
 
 	<generated>

--- a/src/FAST-Java-Model/FASTJavaTypeExpression.class.st
+++ b/src/FAST-Java-Model/FASTJavaTypeExpression.class.st
@@ -13,6 +13,7 @@ I am an abstract class representing a type
 | `javaEnumDeclarationInterfaceOwner` | `FASTJavaTypeExpression` | `interfaces` | `FASTJavaEnumDeclaration` | The enum that implements me|
 | `javaForEachStatementTypeOwner` | `FASTJavaTypeExpression` | `type` | `FASTJavaForEachStatement` | The javaForEachStatement owner (if possible)|
 | `javaInterfaceDeclarationInterfaceOwner` | `FASTJavaTypeExpression` | `interfaces` | `FASTJavaInterfaceDeclaration` | The interface that extends me|
+| `javaTypePatternTypeOwner` | `FASTJavaTypeExpression` | `type` | `FASTJavaTypePattern` | The javaTypePattern type owner (if possible)|
 
 
 
@@ -21,12 +22,13 @@ Class {
 	#name : #FASTJavaTypeExpression,
 	#superclass : #FASTJavaVariableExpression,
 	#instVars : [
-		'#javaForEachStatementTypeOwner => FMOne type: #FASTJavaForEachStatement opposite: #type',
 		'#catchOwner => FMOne type: #FASTJavaCatchPartStatement opposite: #catchedTypes',
-		'#javaClassDeclarationSuperclassOwner => FMOne type: #FASTJavaClassDeclaration opposite: #superclass',
 		'#javaClassDeclarationInterfaceOwner => FMOne type: #FASTJavaClassDeclaration opposite: #interfaces',
+		'#javaClassDeclarationSuperclassOwner => FMOne type: #FASTJavaClassDeclaration opposite: #superclass',
 		'#javaEnumDeclarationInterfaceOwner => FMOne type: #FASTJavaEnumDeclaration opposite: #interfaces',
-		'#javaInterfaceDeclarationInterfaceOwner => FMOne type: #FASTJavaInterfaceDeclaration opposite: #interfaces'
+		'#javaForEachStatementTypeOwner => FMOne type: #FASTJavaForEachStatement opposite: #type',
+		'#javaInterfaceDeclarationInterfaceOwner => FMOne type: #FASTJavaInterfaceDeclaration opposite: #interfaces',
+		'#javaTypePatternTypeOwner => FMOne type: #FASTJavaTypePattern opposite: #type'
 	],
 	#category : #'FAST-Java-Model-Entities'
 }
@@ -184,4 +186,29 @@ FASTJavaTypeExpression >> javaInterfaceDeclarationInterfaceOwnerGroup [
 	<generated>
 	<navigation: 'JavaInterfaceDeclarationInterfaceOwner'>
 	^ MooseSpecializedGroup with: self javaInterfaceDeclarationInterfaceOwner
+]
+
+{ #category : #accessing }
+FASTJavaTypeExpression >> javaTypePatternTypeOwner [
+	"Relation named: #javaTypePatternTypeOwner type: #FASTJavaTypePattern opposite: #type"
+
+	<generated>
+	<FMComment: 'The javaTypePattern type owner (if possible)'>
+	<container>
+	<derived>
+	^ javaTypePatternTypeOwner
+]
+
+{ #category : #accessing }
+FASTJavaTypeExpression >> javaTypePatternTypeOwner: anObject [
+
+	<generated>
+	javaTypePatternTypeOwner := anObject
+]
+
+{ #category : #navigation }
+FASTJavaTypeExpression >> javaTypePatternTypeOwnerGroup [
+	<generated>
+	<navigation: 'JavaTypePatternTypeOwner'>
+	^ MooseSpecializedGroup with: self javaTypePatternTypeOwner
 ]

--- a/src/FAST-Java-Model/FASTJavaTypeName.class.st
+++ b/src/FAST-Java-Model/FASTJavaTypeName.class.st
@@ -10,6 +10,7 @@ I represent the name of a type
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `arrayOwner` | `FASTJavaTAnnotationElement` | `values` | `FASTJavaArrayAnnotationElement` | The ArrayAnnotationElement I am an element of|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -19,6 +20,7 @@ I represent the name of a type
 | `ifConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaIfStatement` | I represent a condition for my owner|
 | `infixOperationLeftOperandOwner` | `FASTTExpression` | `leftOperand` | `FASTJavaInfixOperation` | The left operand (if possible)|
 | `infixOperationRightOperandOwner` | `FASTTExpression` | `rightOperand` | `FASTJavaInfixOperation` | The right operand (if possible)|
+| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 | `javaArrayAccessOwner` | `FASTTExpression` | `expression` | `FASTJavaArrayAccess` | The javaArrayAccess owner (if possible)|
 | `javaArrayArrayAccessOwner` | `FASTTExpression` | `array` | `FASTJavaArrayAccess` | The javaArrayArrayAccess owner (if possible)|
 | `javaArrayInitializers` | `FASTTExpression` | `initializers` | `FASTJavaArrayInitializer` | The owner of the expression|
@@ -36,17 +38,13 @@ I represent the name of a type
 | `javaTypeNameTypeExpressionOwner` | `FASTJavaTypeName` | `typeName` | `FASTJavaClassTypeExpression` | The type expression that owns me|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
-| `parentAnnotation` | `FASTJavaTAnnotationElement` | `elements` | `FASTJavaAnnotation` | An ""argument"" of an annotation, eg. ""unchecked"" in the following annotation:
-	@SuppressWarnings(value=""unchecked"")|
+| `parentAnnotation` | `FASTJavaTAnnotationElement` | `elements` | `FASTJavaAnnotation` | An ""argument"" of an annotation, eg. ""unchecked"" in the following annotation: 	@SuppressWarnings(value=""unchecked"")|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
-| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaTypeParameterExpression.class.st
+++ b/src/FAST-Java-Model/FASTJavaTypeParameterExpression.class.st
@@ -9,6 +9,7 @@ I represent JavaTypeParameter such as `void <T extends Hello> T myMethod()`
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -18,6 +19,7 @@ I represent JavaTypeParameter such as `void <T extends Hello> T myMethod()`
 | `ifConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaIfStatement` | I represent a condition for my owner|
 | `infixOperationLeftOperandOwner` | `FASTTExpression` | `leftOperand` | `FASTJavaInfixOperation` | The left operand (if possible)|
 | `infixOperationRightOperandOwner` | `FASTTExpression` | `rightOperand` | `FASTJavaInfixOperation` | The right operand (if possible)|
+| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 | `javaArrayAccessOwner` | `FASTTExpression` | `expression` | `FASTJavaArrayAccess` | The javaArrayAccess owner (if possible)|
 | `javaArrayArrayAccessOwner` | `FASTTExpression` | `array` | `FASTJavaArrayAccess` | The javaArrayArrayAccess owner (if possible)|
 | `javaArrayInitializers` | `FASTTExpression` | `initializers` | `FASTJavaArrayInitializer` | The owner of the expression|
@@ -34,6 +36,9 @@ I represent JavaTypeParameter such as `void <T extends Hello> T myMethod()`
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
@@ -42,12 +47,6 @@ I represent JavaTypeParameter such as `void <T extends Hello> T myMethod()`
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `types` | `FASTJavaTypeParameterExpression` | `typeParameterOwner` | `FASTJavaClassTypeExpression` | The list of types I extend or implements|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
-| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaTypePattern.class.st
+++ b/src/FAST-Java-Model/FASTJavaTypePattern.class.st
@@ -53,7 +53,7 @@ Example:
 ### Children
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `type` | `FASTJavaTypePattern` | `javaTypePatternTypeOwner` | `FASTJavaVariableExpression` | The type of the declared variable|
+| `type` | `FASTJavaTypePattern` | `javaTypePatternTypeOwner` | `FASTJavaTypeExpression` | The type of the declared variable|
 | `variable` | `FASTJavaTypePattern` | `javaTypePatternVariableOwner` | `FASTJavaVariableExpression` | The local variable declared by this type pattern|
 
 
@@ -72,8 +72,8 @@ Class {
 	#traits : 'FASTTExpression',
 	#classTraits : 'FASTTExpression classTrait',
 	#instVars : [
-		'#variable => FMOne type: #FASTJavaVariableExpression opposite: #javaTypePatternVariableOwner',
-		'#type => FMOne type: #FASTJavaVariableExpression opposite: #javaTypePatternTypeOwner'
+		'#type => FMOne type: #FASTJavaTypeExpression opposite: #javaTypePatternTypeOwner',
+		'#variable => FMOne type: #FASTJavaVariableExpression opposite: #javaTypePatternVariableOwner'
 	],
 	#category : #'FAST-Java-Model-Entities'
 }
@@ -89,7 +89,7 @@ FASTJavaTypePattern class >> annotation [
 
 { #category : #accessing }
 FASTJavaTypePattern >> type [
-	"Relation named: #type type: #FASTJavaVariableExpression opposite: #javaTypePatternTypeOwner"
+	"Relation named: #type type: #FASTJavaTypeExpression opposite: #javaTypePatternTypeOwner"
 
 	<generated>
 	<FMComment: 'The type of the declared variable'>

--- a/src/FAST-Java-Model/FASTJavaTypePattern.class.st
+++ b/src/FAST-Java-Model/FASTJavaTypePattern.class.st
@@ -1,5 +1,14 @@
 "
-I represent a cast expression, e.g. `(int) 0.5`
+This code element defines a type pattern, introduced in Java 16 by [JEP 394](https://openjdk.java.net/jeps/394).
+Example:
+```language=text
+	Object obj = null;
+	boolean longerThanTwo = false;
+	// String s is the type pattern, declaring a local variable
+	if (obj instanceof String s) {
+		longerThanTwo = s.length() > 2;
+	}
+```
 
 ## Relations
 ======================
@@ -37,7 +46,6 @@ I represent a cast expression, e.g. `(int) 0.5`
 | `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
 | `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
 | `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
-| `receiverOwner` | `FASTJavaTReceiver` | `receiver` | `FASTJavaTWithReceiver` | The owner of the receiver|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
@@ -45,8 +53,8 @@ I represent a cast expression, e.g. `(int) 0.5`
 ### Children
 | Relation | Origin | Opposite | Type | Comment |
 |---|
-| `expression` | `FASTJavaCastExpression` | `javaCastExpressionOwner` | `FASTTExpression` | The expression to cast|
-| `type` | `FASTJavaCastExpression` | `javaCastExpressionTypeOwner` | `FASTJavaVariableExpression` | The type into which the expression will be cast|
+| `type` | `FASTJavaTypePattern` | `javaTypePatternTypeOwner` | `FASTJavaVariableExpression` | The type of the declared variable|
+| `variable` | `FASTJavaTypePattern` | `javaTypePatternVariableOwner` | `FASTJavaVariableExpression` | The local variable declared by this type pattern|
 
 
 ## Properties
@@ -59,75 +67,68 @@ I represent a cast expression, e.g. `(int) 0.5`
 
 "
 Class {
-	#name : #FASTJavaCastExpression,
+	#name : #FASTJavaTypePattern,
 	#superclass : #FASTJavaEntity,
-	#traits : 'FASTJavaTReceiver + FASTTExpression',
-	#classTraits : 'FASTJavaTReceiver classTrait + FASTTExpression classTrait',
+	#traits : 'FASTTExpression',
+	#classTraits : 'FASTTExpression classTrait',
 	#instVars : [
-		'#type => FMOne type: #FASTJavaVariableExpression opposite: #javaCastExpressionTypeOwner'
+		'#variable => FMOne type: #FASTJavaVariableExpression opposite: #javaTypePatternVariableOwner',
+		'#type => FMOne type: #FASTJavaVariableExpression opposite: #javaTypePatternTypeOwner'
 	],
 	#category : #'FAST-Java-Model-Entities'
 }
 
 { #category : #meta }
-FASTJavaCastExpression class >> annotation [
+FASTJavaTypePattern class >> annotation [
 
-	<FMClass: #CastExpression super: #FASTJavaEntity>
+	<FMClass: #TypePattern super: #FASTJavaEntity>
 	<package: #'FAST-Java-Model'>
 	<generated>
 	^ self
 ]
 
 { #category : #accessing }
-FASTJavaCastExpression >> expression [
-	"Relation named: #expression type: #FASTTExpression opposite: #javaCastExpressionOwner"
+FASTJavaTypePattern >> type [
+	"Relation named: #type type: #FASTJavaVariableExpression opposite: #javaTypePatternTypeOwner"
 
 	<generated>
-	<FMComment: 'The expression to cast'>
-	<FMProperty: #expression type: #FASTTExpression opposite: #javaCastExpressionOwner>
-	^ self attributeAt: #expression ifAbsent: [ nil ]
-]
-
-{ #category : #accessing }
-FASTJavaCastExpression >> expression: anObject [
-
-	<generated>
-	(self attributeAt: #expression ifAbsentPut: [nil]) == anObject ifTrue: [ ^ anObject ].
-	anObject ifNil: [ | otherSide |
-		otherSide :=  self expression.
-		self attributeAt: #expression put: anObject.
-		otherSide javaCastExpressionOwner: nil ]
-	ifNotNil: [ 
-		self attributeAt: #expression put: anObject.
-		anObject javaCastExpressionOwner: self ]
-]
-
-{ #category : #navigation }
-FASTJavaCastExpression >> expressionGroup [
-	<generated>
-	<navigation: 'Expression'>
-	^ MooseSpecializedGroup with: self expression
-]
-
-{ #category : #accessing }
-FASTJavaCastExpression >> type [
-	"Relation named: #type type: #FASTJavaVariableExpression opposite: #javaCastExpressionTypeOwner"
-
-	<generated>
-	<FMComment: 'The type into which the expression will be cast'>
+	<FMComment: 'The type of the declared variable'>
 	^ type
 ]
 
 { #category : #accessing }
-FASTJavaCastExpression >> type: anObject [
+FASTJavaTypePattern >> type: anObject [
 
 	<generated>
 	type := anObject
 ]
 
 { #category : #navigation }
-FASTJavaCastExpression >> typeGroup [
+FASTJavaTypePattern >> typeGroup [
 	<generated>
 	<navigation: 'Type'>
 	^ MooseSpecializedGroup with: self type
+]
+
+{ #category : #accessing }
+FASTJavaTypePattern >> variable [
+	"Relation named: #variable type: #FASTJavaVariableExpression opposite: #javaTypePatternVariableOwner"
+
+	<generated>
+	<FMComment: 'The local variable declared by this type pattern'>
+	^ variable
+]
+
+{ #category : #accessing }
+FASTJavaTypePattern >> variable: anObject [
+
+	<generated>
+	variable := anObject
+]
+
+{ #category : #navigation }
+FASTJavaTypePattern >> variableGroup [
+	<generated>
+	<navigation: 'Variable'>
+	^ MooseSpecializedGroup with: self variable
 ]

--- a/src/FAST-Java-Model/FASTJavaUnaryExpression.class.st
+++ b/src/FAST-Java-Model/FASTJavaUnaryExpression.class.st
@@ -21,6 +21,7 @@ see: https://docs.oracle.com/javase/tutorial/java/nutsandbolts/op1.html
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -45,6 +46,9 @@ see: https://docs.oracle.com/javase/tutorial/java/nutsandbolts/op1.html
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
@@ -53,11 +57,6 @@ see: https://docs.oracle.com/javase/tutorial/java/nutsandbolts/op1.html
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `expression` | `FASTJavaUnaryExpression` | `javaUnaryExpressionOwner` | `FASTTExpression` | The affected expression|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 
 
 ## Properties

--- a/src/FAST-Java-Model/FASTJavaVariableExpression.class.st
+++ b/src/FAST-Java-Model/FASTJavaVariableExpression.class.st
@@ -40,7 +40,6 @@
 | `javaStringAssertStatementOwner` | `FASTTExpression` | `message` | `FASTJavaAssertStatement` | The assertion which I describe|
 | `javaSynchronizedStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaSynchronizedStatement` | The owner of the synchronized block (if possible)|
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
-| `javaTypePatternTypeOwner` | `FASTJavaVariableExpression` | `type` | `FASTJavaTypePattern` | The javaTypePattern type owner (if possible)|
 | `javaTypePatternVariableOwner` | `FASTJavaVariableExpression` | `variable` | `FASTJavaTypePattern` | The javaTypePattern variable owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVarDeclTypeOwner` | `FASTJavaVariableExpression` | `type` | `FASTJavaVarDeclStatement` | The variable expression owner (if possible)|
@@ -81,7 +80,6 @@ Class {
 		'#javaOuterThisOwner => FMOne type: #FASTJavaOuterThis opposite: #type',
 		'#javaParameterTypeOwner => FMOne type: #FASTJavaParameter opposite: #type',
 		'#javaParameterVariableOwner => FMOne type: #FASTJavaParameter opposite: #variable',
-		'#javaTypePatternTypeOwner => FMOne type: #FASTJavaTypePattern opposite: #type',
 		'#javaTypePatternVariableOwner => FMOne type: #FASTJavaTypePattern opposite: #variable',
 		'#javaVarDeclTypeOwner => FMOne type: #FASTJavaVarDeclStatement opposite: #type',
 		'#javaVariableDeclaratorOwner => FMOne type: #FASTJavaVariableDeclarator opposite: #variable'
@@ -321,31 +319,6 @@ FASTJavaVariableExpression >> javaParameterVariableOwnerGroup [
 	<generated>
 	<navigation: 'JavaParameterVariableOwner'>
 	^ MooseSpecializedGroup with: self javaParameterVariableOwner
-]
-
-{ #category : #accessing }
-FASTJavaVariableExpression >> javaTypePatternTypeOwner [
-	"Relation named: #javaTypePatternTypeOwner type: #FASTJavaTypePattern opposite: #type"
-
-	<generated>
-	<FMComment: 'The javaTypePattern type owner (if possible)'>
-	<container>
-	<derived>
-	^ javaTypePatternTypeOwner
-]
-
-{ #category : #accessing }
-FASTJavaVariableExpression >> javaTypePatternTypeOwner: anObject [
-
-	<generated>
-	javaTypePatternTypeOwner := anObject
-]
-
-{ #category : #navigation }
-FASTJavaVariableExpression >> javaTypePatternTypeOwnerGroup [
-	<generated>
-	<navigation: 'JavaTypePatternTypeOwner'>
-	^ MooseSpecializedGroup with: self javaTypePatternTypeOwner
 ]
 
 { #category : #accessing }

--- a/src/FAST-Java-Model/FASTJavaVariableExpression.class.st
+++ b/src/FAST-Java-Model/FASTJavaVariableExpression.class.st
@@ -7,6 +7,7 @@
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
+| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
 | `conditionalElsePartOwner` | `FASTTExpression` | `elsePart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
 | `conditionalThenPartOwner` | `FASTTExpression` | `thenPart` | `FASTJavaConditionalExpression` | The if owner (if possible)|
@@ -16,6 +17,7 @@
 | `ifConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaIfStatement` | I represent a condition for my owner|
 | `infixOperationLeftOperandOwner` | `FASTTExpression` | `leftOperand` | `FASTJavaInfixOperation` | The left operand (if possible)|
 | `infixOperationRightOperandOwner` | `FASTTExpression` | `rightOperand` | `FASTJavaInfixOperation` | The right operand (if possible)|
+| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 | `javaArrayAccessOwner` | `FASTTExpression` | `expression` | `FASTJavaArrayAccess` | The javaArrayAccess owner (if possible)|
 | `javaArrayArrayAccessOwner` | `FASTTExpression` | `array` | `FASTJavaArrayAccess` | The javaArrayArrayAccess owner (if possible)|
 | `javaArrayInitializers` | `FASTTExpression` | `initializers` | `FASTJavaArrayInitializer` | The owner of the expression|
@@ -38,21 +40,20 @@
 | `javaStringAssertStatementOwner` | `FASTTExpression` | `message` | `FASTJavaAssertStatement` | The assertion which I describe|
 | `javaSynchronizedStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaSynchronizedStatement` | The owner of the synchronized block (if possible)|
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
+| `javaTypePatternTypeOwner` | `FASTJavaVariableExpression` | `type` | `FASTJavaTypePattern` | The javaTypePattern type owner (if possible)|
+| `javaTypePatternVariableOwner` | `FASTJavaVariableExpression` | `variable` | `FASTJavaTypePattern` | The javaTypePattern variable owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVarDeclTypeOwner` | `FASTJavaVariableExpression` | `type` | `FASTJavaVarDeclStatement` | The variable expression owner (if possible)|
 | `javaVariableAssignmentOwner` | `FASTJavaTAssignable` | `variable` | `FASTJavaTWithAssignable` | The owner of the assignment|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
 | `javaVariableDeclaratorOwner` | `FASTJavaVariableExpression` | `variable` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
+| `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
+| `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
 | `receiverOwner` | `FASTJavaTReceiver` | `receiver` | `FASTJavaTWithReceiver` | The owner of the receiver|
 | `returnOwner` | `FASTTExpression` | `expression` | `FASTTReturnStatement` | The return statement that own the expression (if it's the case)|
 | `switchConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaSwitchStatement` | I represent a condition for my owner|
 | `whileConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaWhileStatement` | I represent a condition for my owner|
-
-### Other
-| Relation | Origin | Opposite | Type | Comment |
-|---|
-| `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
-| `invokedIn` | `FASTTNamedEntity` | `invoked` | `FASTTInvocation` | Optional invocation where this name is used|
 
 
 ## Properties
@@ -71,17 +72,19 @@ Class {
 	#traits : 'FASTJavaTAssignable + FASTJavaTReceiver + FASTTVariableExpression',
 	#classTraits : 'FASTJavaTAssignable classTrait + FASTJavaTReceiver classTrait + FASTTVariableExpression classTrait',
 	#instVars : [
-		'#javaVariableDeclaratorOwner => FMOne type: #FASTJavaVariableDeclarator opposite: #variable',
 		'#javaCastExpressionTypeOwner => FMOne type: #FASTJavaCastExpression opposite: #type',
-		'#javaClassPropertyOwner => FMOne type: #FASTJavaClassProperty opposite: #type',
-		'#javaNewExpressionOwner => FMOne type: #FASTJavaNewExpression opposite: #type',
-		'#javaOuterThisOwner => FMOne type: #FASTJavaOuterThis opposite: #type',
 		'#javaCatchParameterOwnler => FMOne type: #FASTJavaCatchPartStatement opposite: #parameter',
+		'#javaClassPropertyOwner => FMOne type: #FASTJavaClassProperty opposite: #type',
 		'#javaMethodReferenceOwner => FMOne type: #FASTJavaMethodReference opposite: #receiver',
 		'#javaMethodTypeOwner => FMOne type: #FASTJavaMethodEntity opposite: #type',
+		'#javaNewExpressionOwner => FMOne type: #FASTJavaNewExpression opposite: #type',
+		'#javaOuterThisOwner => FMOne type: #FASTJavaOuterThis opposite: #type',
 		'#javaParameterTypeOwner => FMOne type: #FASTJavaParameter opposite: #type',
 		'#javaParameterVariableOwner => FMOne type: #FASTJavaParameter opposite: #variable',
-		'#javaVarDeclTypeOwner => FMOne type: #FASTJavaVarDeclStatement opposite: #type'
+		'#javaTypePatternTypeOwner => FMOne type: #FASTJavaTypePattern opposite: #type',
+		'#javaTypePatternVariableOwner => FMOne type: #FASTJavaTypePattern opposite: #variable',
+		'#javaVarDeclTypeOwner => FMOne type: #FASTJavaVarDeclStatement opposite: #type',
+		'#javaVariableDeclaratorOwner => FMOne type: #FASTJavaVariableDeclarator opposite: #variable'
 	],
 	#category : #'FAST-Java-Model-Entities'
 }
@@ -318,6 +321,56 @@ FASTJavaVariableExpression >> javaParameterVariableOwnerGroup [
 	<generated>
 	<navigation: 'JavaParameterVariableOwner'>
 	^ MooseSpecializedGroup with: self javaParameterVariableOwner
+]
+
+{ #category : #accessing }
+FASTJavaVariableExpression >> javaTypePatternTypeOwner [
+	"Relation named: #javaTypePatternTypeOwner type: #FASTJavaTypePattern opposite: #type"
+
+	<generated>
+	<FMComment: 'The javaTypePattern type owner (if possible)'>
+	<container>
+	<derived>
+	^ javaTypePatternTypeOwner
+]
+
+{ #category : #accessing }
+FASTJavaVariableExpression >> javaTypePatternTypeOwner: anObject [
+
+	<generated>
+	javaTypePatternTypeOwner := anObject
+]
+
+{ #category : #navigation }
+FASTJavaVariableExpression >> javaTypePatternTypeOwnerGroup [
+	<generated>
+	<navigation: 'JavaTypePatternTypeOwner'>
+	^ MooseSpecializedGroup with: self javaTypePatternTypeOwner
+]
+
+{ #category : #accessing }
+FASTJavaVariableExpression >> javaTypePatternVariableOwner [
+	"Relation named: #javaTypePatternVariableOwner type: #FASTJavaTypePattern opposite: #variable"
+
+	<generated>
+	<FMComment: 'The javaTypePattern variable owner (if possible)'>
+	<container>
+	<derived>
+	^ javaTypePatternVariableOwner
+]
+
+{ #category : #accessing }
+FASTJavaVariableExpression >> javaTypePatternVariableOwner: anObject [
+
+	<generated>
+	javaTypePatternVariableOwner := anObject
+]
+
+{ #category : #navigation }
+FASTJavaVariableExpression >> javaTypePatternVariableOwnerGroup [
+	<generated>
+	<navigation: 'JavaTypePatternVariableOwner'>
+	^ MooseSpecializedGroup with: self javaTypePatternVariableOwner
 ]
 
 { #category : #accessing }

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCAssignementTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCAssignementTest.class.st
@@ -28,7 +28,7 @@ JavaSmaCCAssignementTest >> testAssignementOperator [
 	sortedAssignements := (fastModel allWithType: FASTJavaAssignmentExpression)
 		sorted: [ :a :b | a startPos < b startPos ].
 
-	sortedAssignements allButLast do: [ :assign |
+	sortedAssignements entities allButLast do: [ :assign |
 		self assert: assign operator equals: '='
 	].
 
@@ -37,31 +37,41 @@ JavaSmaCCAssignementTest >> testAssignementOperator [
 
 { #category : #tests }
 JavaSmaCCAssignementTest >> testAssignmentInArrayAccess [
-	(fastModel allWithType: FASTJavaAssignmentExpression) detect:  [ :assignment | assignment expression class = FASTJavaFloatLiteral ]
-		 ifFound: [ :assignment | self assert: assignment variable class equals: FASTJavaArrayAccess ] ifNone: [ self fail ].
+
+	(fastModel allWithType: FASTJavaAssignmentExpression) entities
+		detect: [ :assignment |
+		assignment expression class = FASTJavaFloatLiteral ]
+		ifFound: [ :assignment |
+			self assert: assignment variable class equals: FASTJavaArrayAccess ]
+		ifNone: [ self fail ]
 ]
 
 { #category : #tests }
 JavaSmaCCAssignementTest >> testAssignmentInFieldAccess [
-	(fastModel allWithType: FASTJavaAssignmentExpression) detect:  [ :assignment | assignment expression class = FASTJavaIntegerLiteral ]
-		 ifFound: [ :assignment | self assert: assignment variable class equals: FASTJavaFieldAccess ] ifNone: [ self fail ]
+
+	(fastModel allWithType: FASTJavaAssignmentExpression) entities
+		detect: [ :assignment |
+		assignment expression class = FASTJavaIntegerLiteral ]
+		ifFound: [ :assignment |
+			self assert: assignment variable class equals: FASTJavaFieldAccess ]
+		ifNone: [ self fail ]
 ]
 
 { #category : #tests }
 JavaSmaCCAssignementTest >> testAssignmentParameter [
-	(fastModel allWithType: FASTJavaAssignmentExpression)
+	(fastModel allWithType: FASTJavaAssignmentExpression) entities
 		detect: [ :assignment | assignment expression name = 'navView' ]
 		ifFound: [ :assignment | self assert: assignment variable name equals: 'navPanel' ]
 		ifNone: [ self fail ].
-	(fastModel allWithType: FASTJavaAssignmentExpression)
+	(fastModel allWithType: FASTJavaAssignmentExpression) entities
 		detect: [ :assignment | assignment expression name = 'deviceView' ]
 		ifFound: [ :assignment | self assert: assignment variable name equals: 'devicePanel' ]
 		ifNone: [ self fail ].
-	(fastModel allWithType: FASTJavaAssignmentExpression)
+	(fastModel allWithType: FASTJavaAssignmentExpression) entities
 		detect: [ :assignment | assignment expression name = 'mapView' ]
 		ifFound: [ :assignment | self assert: assignment variable name equals: 'mapPanel' ]
 		ifNone: [ self fail ].
-	(fastModel allWithType: FASTJavaAssignmentExpression)
+	(fastModel allWithType: FASTJavaAssignmentExpression) entities
 		detect: [ :assignment | assignment expression name = 'archiveView' ]
 		ifFound: [ :assignment | self assert: assignment variable name equals: 'archivePanel' ]
 		ifNone: [ self fail ]

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCInstanceofTypePatternTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCInstanceofTypePatternTest.class.st
@@ -1,0 +1,47 @@
+Class {
+	#name : #JavaSmaCCInstanceofTypePatternTest,
+	#superclass : #JavaSmaCCImporterTest,
+	#category : #'FAST-Java-SmaCC-Importer-Tests'
+}
+
+{ #category : #running }
+JavaSmaCCInstanceofTypePatternTest >> javaMethod [
+	
+	^ 'void f(Object obj) {
+		return obj instanceof Number num;
+	}'
+]
+
+{ #category : #tests }
+JavaSmaCCInstanceofTypePatternTest >> testTypePatternExists [
+
+	self assert: (fastModel allWithType: FASTJavaTypePattern) isNotEmpty
+]
+
+{ #category : #tests }
+JavaSmaCCInstanceofTypePatternTest >> testTypePatternInstanceof [
+
+	self
+		assert:
+		(fastModel allWithType: FASTJavaTypePattern) anyOne parentNode
+		equals: (fastModel allWithType: FASTJavaInfixOperation) anyOne
+]
+
+{ #category : #tests }
+JavaSmaCCInstanceofTypePatternTest >> testTypePatternType [
+
+	self
+		assert:
+		(fastModel allWithType: FASTJavaTypePattern) anyOne type typeName
+			name
+		equals: 'Number'
+]
+
+{ #category : #tests }
+JavaSmaCCInstanceofTypePatternTest >> testTypePatternVariable [
+
+	self
+		assert:
+		(fastModel allWithType: FASTJavaTypePattern) anyOne variable name
+		equals: 'num'
+]

--- a/src/FAST-Java-SmaCC-Importer/JavaSmaCCProgramNodeImporterVisitor.class.st
+++ b/src/FAST-Java-SmaCC-Importer/JavaSmaCCProgramNodeImporterVisitor.class.st
@@ -1216,7 +1216,7 @@ JavaSmaCCProgramNodeImporterVisitor >> visitSwitchBlockStatementGroup: aSwitchBl
 		addToModel:
 			(aSwitchBlockStatementGroup labels anyOne class = JavaSwitchLabelNode
 				ifTrue: [ FASTJavaLabeledCaseStatement new
-						label: (self clone accept: aSwitchBlockStatementGroup labels anyOne constant);
+						label: (self clone accept: aSwitchBlockStatementGroup labels anyOne constants anyOne);
 						yourself ]
 				ifFalse: [ FASTJavaDefaultCaseStatement new ]).
 	self setStartEndPos: aSwitchBlockStatementGroup.

--- a/src/FAST-Java-SmaCC-Importer/JavaSmaCCProgramNodeImporterVisitor.class.st
+++ b/src/FAST-Java-SmaCC-Importer/JavaSmaCCProgramNodeImporterVisitor.class.st
@@ -747,6 +747,27 @@ JavaSmaCCProgramNodeImporterVisitor >> visitInitializer: aInitializer [
 	^ currentFASTEntity
 ]
 
+{ #category : #generated }
+JavaSmaCCProgramNodeImporterVisitor >> visitInstanceofPatternExpression: anInstanceofPatternExpression [
+	"SmaCC gives a single node representing both the instanceof operation and the type pattern.
+	FAST splits it into an infix operation with the type pattern as the right operand."
+
+	self
+		create: FASTJavaInfixOperation
+		from: anInstanceofPatternExpression.
+	currentFASTEntity leftOperand:
+		(self clone accept: anInstanceofPatternExpression object).
+	currentFASTEntity rightOperand:
+		((self addToModel: FASTJavaTypePattern new)
+			 startPos: anInstanceofPatternExpression type startPosition;
+			 endPos: anInstanceofPatternExpression variable stopPosition;
+			 type: (self clone accept: anInstanceofPatternExpression type);
+			 variable:
+				 (self clone accept: anInstanceofPatternExpression variable)).
+	currentFASTEntity operator: 'instanceof'.
+	^ currentFASTEntity
+]
+
 { #category : #visitor }
 JavaSmaCCProgramNodeImporterVisitor >> visitIntType: aByteType [
 	currentFASTEntity := self


### PR DESCRIPTION
Pattern matching in Java allows to declare a variable when a condition is true, e.g. autocasting when using `instanceof`.
```java
Object obj = null;
boolean longerThanTwo = false;
// String s is the type pattern, declaring a local variable
if (obj instanceof String s) {
	longerThanTwo = s.length() > 2;
}
```

SmaCC currently implements such a case as a specialized `instanceof` node, but the uses of pattern matching will grow over time, e.g. for switch statements.

Spoon also categorizes it as a separate entity from the operation.
<img width="454" alt="image" src="https://github.com/moosetechnology/FAST-JAVA/assets/78592838/6ca7c0e8-bf39-4576-a47a-21a7820cdfbe">

For these reasons, it is implemented in FAST as a `TypePattern` expression and declares a single variable.