### PR TITLE
fix: FASTJavaAnnotation can have FASTJavaInfixOperation has element

### DIFF
--- a/src/FAST-Java-Model-Generator/FASTJavaMetamodelGenerator.class.st
+++ b/src/FAST-Java-Model-Generator/FASTJavaMetamodelGenerator.class.st
@@ -908,6 +908,7 @@ FASTJavaMetamodelGenerator >> defineHierarchy [
 
 	javaInfixOperation --|> tExpression.
 	javaInfixOperation --|> tReceiver.
+	javaInfixOperation --|> tAnnotationElement.
 
 	javaBreakStatement --|> tStatement.
 	javaCaseStatement --|> tStatementBlock.

--- a/src/FAST-Java-Model/FASTJavaInfixOperation.class.st
+++ b/src/FAST-Java-Model/FASTJavaInfixOperation.class.st
@@ -13,6 +13,7 @@ ex:
 | Relation | Origin | Opposite | Type | Comment |
 |---|
 | `argumentOwner` | `FASTTExpression` | `arguments` | `FASTTWithArguments` | my owner|
+| `arrayOwner` | `FASTJavaTAnnotationElement` | `values` | `FASTJavaArrayAnnotationElement` | The ArrayAnnotationElement I am an element of|
 | `assertConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaAssertStatement` | I represent a condition for my owner|
 | `assignedIn` | `FASTTExpression` | `expression` | `FASTTAssignment` | Optional assignment where this expression is used|
 | `conditionalConditionOwner` | `FASTTExpression` | `condition` | `FASTJavaConditionalExpression` | I represent a condition for my owner|
@@ -39,6 +40,7 @@ ex:
 | `javaThrowStatementOwner` | `FASTTExpression` | `expression` | `FASTJavaThrowStatement` | The javaThrowStatement owner (if possible)|
 | `javaUnaryExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaUnaryExpression` | The javaUnaryExpression owner (if possible)|
 | `javaVariableDeclaratorExpressionOwner` | `FASTTExpression` | `expression` | `FASTJavaVariableDeclarator` | The javaVariableDeclarator owner (if possible)|
+| `parentAnnotation` | `FASTJavaTAnnotationElement` | `elements` | `FASTJavaAnnotation` | An ""argument"" of an annotation, eg. ""unchecked"" in the following annotation: 	@SuppressWarnings(value=""unchecked"")|
 | `parentExpression` | `FASTTExpression` | `expression` | `FASTTUnaryExpression` | Parent (unary) expression|
 | `parentExpressionLeft` | `FASTTExpression` | `leftOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am left side|
 | `parentExpressionRight` | `FASTTExpression` | `rightOperand` | `FASTTBinaryExpression` | Parent (binary) expression of which I am right side|
@@ -67,8 +69,8 @@ ex:
 Class {
 	#name : 'FASTJavaInfixOperation',
 	#superclass : 'FASTJavaEntity',
-	#traits : 'FASTJavaTReceiver + FASTTExpression',
-	#classTraits : 'FASTJavaTReceiver classTrait + FASTTExpression classTrait',
+	#traits : 'FASTJavaTAnnotationElement + FASTJavaTReceiver + FASTTExpression',
+	#classTraits : 'FASTJavaTAnnotationElement classTrait + FASTJavaTReceiver classTrait + FASTTExpression classTrait',
 	#instVars : [
 		'#operator => FMProperty'
 	],

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCAnnotationWithArrayElementTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCAnnotationWithArrayElementTest.class.st
@@ -8,7 +8,7 @@ Class {
 	#package : 'FAST-Java-SmaCC-Importer-Tests'
 }
 
-{ #category : 'as yet unclassified' }
+{ #category : 'accessing' }
 JavaSmaCCAnnotationWithArrayElementTest >> javaMethod [
 	^ '@Useless( {"hello", "world"} )
 	void arrayLiteral() {

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCAnnotationWithArrayElementTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCAnnotationWithArrayElementTest.class.st
@@ -8,7 +8,7 @@ Class {
 	#package : 'FAST-Java-SmaCC-Importer-Tests'
 }
 
-{ #category : 'accessing' }
+{ #category : 'as yet unclassified' }
 JavaSmaCCAnnotationWithArrayElementTest >> javaMethod [
 	^ '@Useless( {"hello", "world"} )
 	void arrayLiteral() {
@@ -27,7 +27,7 @@ JavaSmaCCAnnotationWithArrayElementTest >> testNumberOfElementsToAnnotation [
 	self assert: (fastModel allWithType: FASTJavaAnnotation) anyOne elements size equals: 1
 ]
 
-{ #category : 'tests' }
+{ #category : 'as yet unclassified' }
 JavaSmaCCAnnotationWithArrayElementTest >> testNumberOfInitializedElement [
 	self assert: (fastModel allWithType: FASTJavaArrayAnnotationElement) first values size equals: 2
 ]

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCAnnotationWithInfixElementTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCAnnotationWithInfixElementTest.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : 'JavaSmaCCAnnotationWithInfixElementTest',
+	#superclass : 'JavaSmaCCImporterTest',
+	#instVars : [
+		'methodNewArray'
+	],
+	#category : 'FAST-Java-SmaCC-Importer-Tests',
+	#package : 'FAST-Java-SmaCC-Importer-Tests'
+}
+
+{ #category : 'running' }
+JavaSmaCCAnnotationWithInfixElementTest >> javaMethod [
+	^ '@Useless( {"hello"+ "world"} )
+	void concatenation() {
+}'
+]
+
+{ #category : 'tests' }
+JavaSmaCCAnnotationWithInfixElementTest >> testElementsType [
+	self
+		assert: (fastModel allWithType: FASTJavaAnnotation) anyOne elements anyOne class
+		equals: FASTJavaArrayAnnotationElement 
+]
+
+{ #category : 'tests' }
+JavaSmaCCAnnotationWithInfixElementTest >> testNumberOfElementsToAnnotation [
+	self assert: (fastModel allWithType: FASTJavaAnnotation) anyOne elements size equals: 1
+]

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCAnnotationWithInfixElementTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCAnnotationWithInfixElementTest.class.st
@@ -10,7 +10,7 @@ Class {
 
 { #category : 'running' }
 JavaSmaCCAnnotationWithInfixElementTest >> javaMethod [
-	^ '@Useless( {"hello"+ "world"} )
+	^ '@Useless( "hello"+ "world" )
 	void concatenation() {
 }'
 ]
@@ -19,7 +19,7 @@ JavaSmaCCAnnotationWithInfixElementTest >> javaMethod [
 JavaSmaCCAnnotationWithInfixElementTest >> testElementsType [
 	self
 		assert: (fastModel allWithType: FASTJavaAnnotation) anyOne elements anyOne class
-		equals: FASTJavaArrayAnnotationElement 
+		equals: FASTJavaInfixOperation 
 ]
 
 { #category : 'tests' }


### PR DESCRIPTION
Add of tAnnotationElement trait to FASTJavaInfixOperation because in this case:

```java
@Annotation( "hello"+ "world" )
	void concatenation() {
}
```

FASTJavaAnnotation element can be a FASTJavaInfixOperation