### PR TITLE
Fix visitors + Apply `children` -> `containedEntities`

### DIFF
--- a/src/FAST-Java-Model/FASTJavaEntity.extension.st
+++ b/src/FAST-Java-Model/FASTJavaEntity.extension.st
@@ -1,7 +1,0 @@
-Extension { #name : 'FASTJavaEntity' }
-
-{ #category : '*FAST-Java-Model-Extension' }
-FASTJavaEntity >> exporterClassName [
-
-	^ #FASTJavaExportVisitor
-]

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCCClassPropertyTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCCClassPropertyTest.class.st
@@ -17,10 +17,16 @@ JavaSmaCCCClassPropertyTest >> javaMethod [
 
 { #category : 'tests' }
 JavaSmaCCCClassPropertyTest >> testClassPropertyName [
-	self assert: fastMethod statements asOrderedCollection fourth children anyOne receiver fieldName equals: 'editableTablelist'
+
+	self
+		assert: fastMethod statements asOrderedCollection fourth containedEntities anyOne receiver fieldName
+		equals: 'editableTablelist'
 ]
 
 { #category : 'tests' }
 JavaSmaCCCClassPropertyTest >> testClassPropertyType [
-	self assert: fastMethod statements asOrderedCollection fourth children anyOne receiver class equals: FASTJavaClassProperty
+
+	self
+		assert: fastMethod statements asOrderedCollection fourth containedEntities anyOne receiver class
+		equals: FASTJavaClassProperty
 ]

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCCharacterLiteralTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCCharacterLiteralTest.class.st
@@ -17,28 +17,15 @@ JavaSmaCCCharacterLiteralTest >> javaMethod [
 { #category : 'tests' }
 JavaSmaCCCharacterLiteralTest >> testCharacterLiteralType [
 
-	self
-		assert: fastMethod statements first children anyOne arguments first class
-		equals: FASTJavaCharacterLiteral.
-	self
-		assert: fastMethod statements second children anyOne arguments first class
-		equals: FASTJavaCharacterLiteral.
-	self
-		assert: fastMethod statements third children anyOne arguments first class
-		equals: FASTJavaCharacterLiteral.
+	self assert: fastMethod statements first containedEntities anyOne arguments first class equals: FASTJavaCharacterLiteral.
+	self assert: fastMethod statements second containedEntities anyOne arguments first class equals: FASTJavaCharacterLiteral.
+	self assert: fastMethod statements third containedEntities anyOne arguments first class equals: FASTJavaCharacterLiteral
 ]
 
 { #category : 'tests' }
 JavaSmaCCCharacterLiteralTest >> testCharacterLiteralValue [
 
-	self
-		assert: fastMethod statements first children anyOne arguments first primitiveValue
-		equals: 'A'.
-	self
-		assert: fastMethod statements second children anyOne arguments first primitiveValue
-		equals: '\n'.
-	self
-		assert: fastMethod statements third children anyOne arguments first primitiveValue
-		equals: '\u0000'.
-
+	self assert: fastMethod statements first containedEntities anyOne arguments first primitiveValue equals: 'A'.
+	self assert: fastMethod statements second containedEntities anyOne arguments first primitiveValue equals: '\n'.
+	self assert: fastMethod statements third containedEntities anyOne arguments first primitiveValue equals: '\u0000'
 ]

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCMethodCastTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCMethodCastTest.class.st
@@ -17,21 +17,25 @@ JavaSmaCCMethodCastTest >> javaMethod [
 
 { #category : 'tests' }
 JavaSmaCCMethodCastTest >> testCastAsAReceiverOfAnInvocation [
-	self assert: fastMethod statements third children anyOne receiver class equals: FASTJavaCastExpression
+
+	self assert: fastMethod statements third containedEntities anyOne receiver class equals: FASTJavaCastExpression
 ]
 
 { #category : 'tests' }
 JavaSmaCCMethodCastTest >> testCastExpressionName [
-	self assert: fastMethod statements third children anyOne receiver expression fieldName equals: 'pListModel'
+
+	self assert: fastMethod statements third containedEntities anyOne receiver expression fieldName equals: 'pListModel'
 ]
 
 { #category : 'tests' }
 JavaSmaCCMethodCastTest >> testCastExpressionType [
-	self assert: fastMethod statements third children anyOne receiver expression class equals: FASTJavaClassProperty
+
+	self assert: fastMethod statements third containedEntities anyOne receiver expression class equals: FASTJavaClassProperty
 ]
 
 { #category : 'tests' }
 JavaSmaCCMethodCastTest >> testCastType [
-	self assert: fastMethod statements third children anyOne receiver type class equals: FASTJavaClassTypeExpression.
-	self assert: fastMethod statements third children anyOne receiver type fullName equals: 'IEditableListModel'
+
+	self assert: fastMethod statements third containedEntities anyOne receiver type class equals: FASTJavaClassTypeExpression.
+	self assert: fastMethod statements third containedEntities anyOne receiver type fullName equals: 'IEditableListModel'
 ]

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCMethodInvocationWithConditionalAsReceiverTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCMethodInvocationWithConditionalAsReceiverTest.class.st
@@ -17,5 +17,6 @@ JavaSmaCCMethodInvocationWithConditionalAsReceiverTest >> javaMethod [
 
 { #category : 'tests' }
 JavaSmaCCMethodInvocationWithConditionalAsReceiverTest >> testClassPropertyReceiverMethodInvocations [
-	self assert: fastMethod statements first children anyOne receiver class equals: FASTJavaConditionalExpression
+
+	self assert: fastMethod statements first containedEntities anyOne receiver class equals: FASTJavaConditionalExpression
 ]

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCMethodInvocationWithParamAndReceiverTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCMethodInvocationWithParamAndReceiverTest.class.st
@@ -67,7 +67,7 @@ JavaSmaCCMethodInvocationWithParamAndReceiverTest >> testNumberOfMethodInvocatio
 	self
 		assert: fastModel statementBlock containedEntities anyOne containedEntities anyOne expression receiver class
 		equals: FASTJavaMethodInvocation.
-	self assert: fastModel statementBlock containedEntities anyOne children anyOne expression receiver receiver equals: nil
+	self assert: fastModel statementBlock containedEntities anyOne containedEntities anyOne expression receiver receiver equals: nil
 ]
 
 { #category : 'tests' }

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCMethodInvocationWithParamAndReceiverTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCMethodInvocationWithParamAndReceiverTest.class.st
@@ -43,54 +43,76 @@ JavaSmaCCMethodInvocationWithParamAndReceiverTest >> setUp [
 
 { #category : 'tests' }
 JavaSmaCCMethodInvocationWithParamAndReceiverTest >> testClassPropertyReceiverMethodInvocations [
-	self assert: methodInvocationWithClassPropertyAsReceiver statements first children anyOne receiver class equals: FASTJavaClassProperty
+
+	self
+		assert: methodInvocationWithClassPropertyAsReceiver statements first containedEntities anyOne receiver class
+		equals: FASTJavaClassProperty
 ]
 
 { #category : 'tests' }
 JavaSmaCCMethodInvocationWithParamAndReceiverTest >> testNumberOfArguments [
-	self assert: fastModel statementBlock children anyOne children anyOne expression arguments size equals: 2.
-	self assert: fastModel statementBlock children anyOne children anyOne expression receiver arguments size equals: 2
+
+	self assert: fastModel statementBlock containedEntities anyOne containedEntities anyOne expression arguments size equals: 2.
+	self
+		assert: fastModel statementBlock containedEntities anyOne containedEntities anyOne expression receiver arguments size
+		equals: 2
 ]
 
 { #category : 'tests' }
 JavaSmaCCMethodInvocationWithParamAndReceiverTest >> testNumberOfMethodInvocations [
-	self assert: fastModel statementBlock children anyOne children anyOne expression class equals: FASTJavaMethodInvocation.
-	self assert: fastModel statementBlock children anyOne children anyOne expression receiver class equals: FASTJavaMethodInvocation.
-	self assert: fastModel statementBlock children anyOne children anyOne expression receiver receiver equals: nil
+
+	self
+		assert: fastModel statementBlock containedEntities anyOne containedEntities anyOne expression class
+		equals: FASTJavaMethodInvocation.
+	self
+		assert: fastModel statementBlock containedEntities anyOne containedEntities anyOne expression receiver class
+		equals: FASTJavaMethodInvocation.
+	self assert: fastModel statementBlock containedEntities anyOne children anyOne expression receiver receiver equals: nil
 ]
 
 { #category : 'tests' }
 JavaSmaCCMethodInvocationWithParamAndReceiverTest >> testReceiverIsInModel [
+
 	self
-		assert: methodInvocationWithVariableAsReceiver statements first children anyOne receiver localMooseModel
+		assert: methodInvocationWithVariableAsReceiver statements first containedEntities anyOne receiver localMooseModel
 		equals: methodInvocationWithVariableAsReceiver localMooseModel
 ]
 
 { #category : 'tests' }
 JavaSmaCCMethodInvocationWithParamAndReceiverTest >> testReceiverKnowTheCallingMethod [
+
 	self
-		assert: methodInvocationWithVariableAsReceiver statements first children anyOne receiver parentNode
-		equals: methodInvocationWithVariableAsReceiver statements first children anyOne
+		assert: methodInvocationWithVariableAsReceiver statements first containedEntities anyOne receiver parentNode
+		equals: methodInvocationWithVariableAsReceiver statements first containedEntities anyOne
 ]
 
 { #category : 'tests' }
 JavaSmaCCMethodInvocationWithParamAndReceiverTest >> testReceiverMethodInvocations [
-	self assert: fastModel statementBlock children anyOne children anyOne expression receiver class equals: FASTJavaMethodInvocation.
-	self assert: fastModel statementBlock children anyOne children anyOne expression receiver receiver equals: nil.
-	self assert: methodInvocationWithVariableAsReceiver statements first children anyOne receiver class equals: FASTJavaIdentifier
+
+	self
+		assert: fastModel statementBlock containedEntities anyOne containedEntities anyOne expression receiver class
+		equals: FASTJavaMethodInvocation.
+	self assert: fastModel statementBlock containedEntities anyOne containedEntities anyOne expression receiver receiver equals: nil.
+	self
+		assert: methodInvocationWithVariableAsReceiver statements first containedEntities anyOne receiver class
+		equals: FASTJavaIdentifier
 ]
 
 { #category : 'tests' }
 JavaSmaCCMethodInvocationWithParamAndReceiverTest >> testTypeOfArguments [
+
 	self
-		assert: fastModel statementBlock children anyOne children anyOne expression arguments first class
+		assert: fastModel statementBlock containedEntities anyOne containedEntities anyOne expression arguments first class
 		equals: FASTJavaIntegerLiteral.
 	self
-		assert: fastModel statementBlock children anyOne children anyOne expression arguments second class
+		assert: fastModel statementBlock containedEntities anyOne containedEntities anyOne expression arguments second class
 		equals: FASTJavaIntegerLiteral
 ]
 
 { #category : 'tests' }
 JavaSmaCCMethodInvocationWithParamAndReceiverTest >> testVariableReceiverMethodInvocations [
-	self assert: methodInvocationWithVariableAsReceiver statements first children anyOne receiver class equals: FASTJavaIdentifier
+
+	self
+		assert: methodInvocationWithVariableAsReceiver statements first containedEntities anyOne receiver class
+		equals: FASTJavaIdentifier
 ]

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCNewInnerClassTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCNewInnerClassTest.class.st
@@ -17,15 +17,18 @@ JavaSmaCCNewInnerClassTest >> javaMethod [
 
 { #category : 'tests' }
 JavaSmaCCNewInnerClassTest >> testNewClassType [
-	self assert: fastMethod statements first children anyOne arguments anyOne class equals: FASTJavaNewExpression
+
+	self assert: fastMethod statements first containedEntities anyOne arguments anyOne class equals: FASTJavaNewExpression
 ]
 
 { #category : 'tests' }
 JavaSmaCCNewInnerClassTest >> testNewName [
-	self assert: fastMethod statements anyOne children anyOne arguments anyOne type fullName equals: 'InnerClass'
+
+	self assert: fastMethod statements anyOne containedEntities anyOne arguments anyOne type fullName equals: 'InnerClass'
 ]
 
 { #category : 'tests' }
 JavaSmaCCNewInnerClassTest >> testNewType [
-	self assert: fastMethod statements first children anyOne class equals: FASTJavaMethodInvocation
+
+	self assert: fastMethod statements first containedEntities anyOne class equals: FASTJavaMethodInvocation
 ]

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCNewTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCNewTest.class.st
@@ -14,10 +14,12 @@ JavaSmaCCNewTest >> javaMethod [
 
 { #category : 'tests' }
 JavaSmaCCNewTest >> testNewName [
-	self assert: fastMethod statements anyOne children anyOne type fullName equals: 'Patate'
+
+	self assert: fastMethod statements anyOne containedEntities anyOne type fullName equals: 'Patate'
 ]
 
 { #category : 'tests' }
 JavaSmaCCNewTest >> testNewType [
-	self assert: fastMethod statements first children anyOne class equals: FASTJavaNewExpression
+
+	self assert: fastMethod statements first containedEntities anyOne class equals: FASTJavaNewExpression
 ]

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCStringLiteralTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCStringLiteralTest.class.st
@@ -14,10 +14,12 @@ JavaSmaCCStringLiteralTest >> javaMethod [
 
 { #category : 'tests' }
 JavaSmaCCStringLiteralTest >> testStringLiteralType [
-	self assert: fastMethod statements first children anyOne arguments first class equals: FASTJavaStringLiteral
+
+	self assert: fastMethod statements first containedEntities anyOne arguments first class equals: FASTJavaStringLiteral
 ]
 
 { #category : 'tests' }
 JavaSmaCCStringLiteralTest >> testStringLiteralValue [
-	self assert: fastMethod statements first children anyOne arguments first primitiveValue equals: 'Patate'
+
+	self assert: fastMethod statements first containedEntities anyOne arguments first primitiveValue equals: 'Patate'
 ]

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCThrowStatementTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCThrowStatementTest.class.st
@@ -23,7 +23,10 @@ JavaSmaCCThrowStatementTest >> testThrowStatementParent [
 
 { #category : 'tests' }
 JavaSmaCCThrowStatementTest >> testThrowStatementParentAsChild [
-	self assert: (fastModel allWithType: FASTJavaThrowStatement) anyOne equals: fastMethod statements anyOne thenPart children anyOne
+
+	self
+		assert: (fastModel allWithType: FASTJavaThrowStatement) anyOne
+		equals: fastMethod statements anyOne thenPart containedEntities anyOne
 ]
 
 { #category : 'tests' }

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCUnaryPostDecrementExpressionTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCUnaryPostDecrementExpressionTest.class.st
@@ -14,20 +14,24 @@ JavaSmaCCUnaryPostDecrementExpressionTest >> javaMethod [
 
 { #category : 'tests' }
 JavaSmaCCUnaryPostDecrementExpressionTest >> testUnaryExpressionIsPrefixed [
-	self deny: fastMethod statements first children anyOne isPrefixedUnaryExpression
+
+	self deny: fastMethod statements first containedEntities anyOne isPrefixedUnaryExpression
 ]
 
 { #category : 'tests' }
 JavaSmaCCUnaryPostDecrementExpressionTest >> testUnaryExpressionOperator [
-	self assert: fastMethod statements first children anyOne operator equals: '--'
+
+	self assert: fastMethod statements first containedEntities anyOne operator equals: '--'
 ]
 
 { #category : 'tests' }
 JavaSmaCCUnaryPostDecrementExpressionTest >> testUnaryExpressionOperatorType [
-	self assert: fastMethod statements first children anyOne operator class equals: ByteString
+
+	self assert: fastMethod statements first containedEntities anyOne operator class equals: ByteString
 ]
 
 { #category : 'tests' }
 JavaSmaCCUnaryPostDecrementExpressionTest >> testUnaryExpressionType [
-	self assert: fastMethod statements first children anyOne class equals: FASTJavaUnaryExpression
+
+	self assert: fastMethod statements first containedEntities anyOne class equals: FASTJavaUnaryExpression
 ]

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCUnaryPostIncrementExpressionTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCUnaryPostIncrementExpressionTest.class.st
@@ -14,20 +14,24 @@ JavaSmaCCUnaryPostIncrementExpressionTest >> javaMethod [
 
 { #category : 'tests' }
 JavaSmaCCUnaryPostIncrementExpressionTest >> testUnaryExpressionIsPrefixed [
-	self deny: fastMethod statements first children anyOne isPrefixedUnaryExpression
+
+	self deny: fastMethod statements first containedEntities anyOne isPrefixedUnaryExpression
 ]
 
 { #category : 'tests' }
 JavaSmaCCUnaryPostIncrementExpressionTest >> testUnaryExpressionOperator [
-	self assert: fastMethod statements first children anyOne operator equals: '++'
+
+	self assert: fastMethod statements first containedEntities anyOne operator equals: '++'
 ]
 
 { #category : 'tests' }
 JavaSmaCCUnaryPostIncrementExpressionTest >> testUnaryExpressionOperatorType [
-	self assert: fastMethod statements first children anyOne operator class equals: ByteString
+
+	self assert: fastMethod statements first containedEntities anyOne operator class equals: ByteString
 ]
 
 { #category : 'tests' }
 JavaSmaCCUnaryPostIncrementExpressionTest >> testUnaryExpressionType [
-	self assert: fastMethod statements first children anyOne class equals: FASTJavaUnaryExpression
+
+	self assert: fastMethod statements first containedEntities anyOne class equals: FASTJavaUnaryExpression
 ]

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCUnaryPreDecrementExpressionTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCUnaryPreDecrementExpressionTest.class.st
@@ -14,20 +14,24 @@ JavaSmaCCUnaryPreDecrementExpressionTest >> javaMethod [
 
 { #category : 'tests' }
 JavaSmaCCUnaryPreDecrementExpressionTest >> testUnaryExpressionIsPrefixed [
-	self assert: fastMethod statements first children anyOne isPrefixedUnaryExpression
+
+	self assert: fastMethod statements first containedEntities anyOne isPrefixedUnaryExpression
 ]
 
 { #category : 'tests' }
 JavaSmaCCUnaryPreDecrementExpressionTest >> testUnaryExpressionOperator [
-	self assert: fastMethod statements first children anyOne operator equals: '--'
+
+	self assert: fastMethod statements first containedEntities anyOne operator equals: '--'
 ]
 
 { #category : 'tests' }
 JavaSmaCCUnaryPreDecrementExpressionTest >> testUnaryExpressionOperatorType [
-	self assert: fastMethod statements first children anyOne operator class equals: ByteString
+
+	self assert: fastMethod statements first containedEntities anyOne operator class equals: ByteString
 ]
 
 { #category : 'tests' }
 JavaSmaCCUnaryPreDecrementExpressionTest >> testUnaryExpressionType [
-	self assert: fastMethod statements first children anyOne class equals: FASTJavaUnaryExpression
+
+	self assert: fastMethod statements first containedEntities anyOne class equals: FASTJavaUnaryExpression
 ]

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCUnaryPreIncrementExpressionTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCUnaryPreIncrementExpressionTest.class.st
@@ -14,15 +14,18 @@ JavaSmaCCUnaryPreIncrementExpressionTest >> javaMethod [
 
 { #category : 'tests' }
 JavaSmaCCUnaryPreIncrementExpressionTest >> testUnaryExpressionIsPrefixed [
-	self assert: fastMethod statements first children anyOne isPrefixedUnaryExpression
+
+	self assert: fastMethod statements first containedEntities anyOne isPrefixedUnaryExpression
 ]
 
 { #category : 'tests' }
 JavaSmaCCUnaryPreIncrementExpressionTest >> testUnaryExpressionOperator [
-	self assert: fastMethod statements first children anyOne operator equals: '++'
+
+	self assert: fastMethod statements first containedEntities anyOne operator equals: '++'
 ]
 
 { #category : 'tests' }
 JavaSmaCCUnaryPreIncrementExpressionTest >> testUnaryExpressionType [
-	self assert: fastMethod statements first children anyOne class equals: FASTJavaUnaryExpression
+
+	self assert: fastMethod statements first containedEntities anyOne class equals: FASTJavaUnaryExpression
 ]

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCWhileWhileMethodTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCWhileWhileMethodTest.class.st
@@ -47,7 +47,10 @@ JavaSmaCCWhileWhileMethodTest >> testFirstWhileConditionType [
 
 { #category : 'tests' }
 JavaSmaCCWhileWhileMethodTest >> testNestedWhileBodyContentType [
-	self assert: fastMethod statements third body statements first body children anyOne class equals: FASTJavaAssignmentExpression
+
+	self
+		assert: fastMethod statements third body statements first body containedEntities anyOne class
+		equals: FASTJavaAssignmentExpression
 ]
 
 { #category : 'tests' }

--- a/src/FAST-Java-Tools-Tests/FASTJavaExportVisitorTest.class.st
+++ b/src/FAST-Java-Tools-Tests/FASTJavaExportVisitorTest.class.st
@@ -648,6 +648,17 @@ FASTJavaExportVisitorTest >> testVisitFASTJavaExpressionParenthesesUnaryWithSub 
 '
 ]
 
+{ #category : 'test from FAST model' }
+FASTJavaExportVisitorTest >> testVisitFASTJavaExpressionStatement [
+	| node |
+	node := builder exprStatement: (builder invocation: 'methodA' recvr: nil args: #()).
+	self
+		export: node
+		equals: 'methodA();
+'.
+
+]
+
 { #category : 'test from source code' }
 FASTJavaExportVisitorTest >> testVisitFASTJavaFieldAccessOnSuper [
 	
@@ -913,6 +924,23 @@ FASTJavaExportVisitorTest >> testVisitFASTJavaLambdaExpressionStatementBlock [
 ;
 }
 '
+]
+
+{ #category : 'test from FAST model' }
+FASTJavaExportVisitorTest >> testVisitFASTJavaLiterals [
+	self
+		export: (builder literalNull)
+		equals: 'null'.
+	self
+		export: (builder literalInt: 42)
+		equals: '42'.
+	self
+		export: (builder literalFloat: '42f')
+		equals: '42f'.
+	self
+		export: (builder literalString: 'a string')
+		equals: '"a string"'.
+
 ]
 
 { #category : 'test from FAST model' }
@@ -1420,32 +1448,4 @@ FASTJavaExportVisitorTest >> testVisitFASTSwitchCaseDefault [
     break;
 }
 '
-]
-
-{ #category : 'test from FAST model' }
-FASTJavaExportVisitorTest >> testVisitFASTTExpressionStatement [
-	| node |
-	node := builder exprStatement: (builder invocation: 'methodA' recvr: nil args: #()).
-	self
-		export: node
-		equals: 'methodA();
-'.
-
-]
-
-{ #category : 'test from FAST model' }
-FASTJavaExportVisitorTest >> testVisitFASTTLiterals [
-	self
-		export: (builder literalNull)
-		equals: 'null'.
-	self
-		export: (builder literalInt: 42)
-		equals: '42'.
-	self
-		export: (builder literalFloat: '42f')
-		equals: '42f'.
-	self
-		export: (builder literalString: 'a string')
-		equals: '"a string"'.
-
 ]

--- a/src/FAST-Java-Tools/FASTJavaExportVisitor.class.st
+++ b/src/FAST-Java-Tools/FASTJavaExportVisitor.class.st
@@ -203,11 +203,9 @@ FASTJavaExportVisitor >> visitFASTJavaArrayAnnotationElement: aFASTJavaArrayAnno
 FASTJavaExportVisitor >> visitFASTJavaArrayInitializer: aFASTJavaArrayInitializer [
 	self checkForComments: aFASTJavaArrayInitializer andDo: [
 		self unindented: '{ '.
-		self
-			visitNodeListSeparatedByCommas: aFASTJavaArrayInitializer initializers.
+		self visitNodeListSeparatedByCommas: aFASTJavaArrayInitializer initializers.
 		self unindented: ' }'.
 	]
-
 ]
 
 { #category : 'visiting expression' }
@@ -262,6 +260,13 @@ FASTJavaExportVisitor >> visitFASTJavaBlockOrStatement: aFASTJavaStatement [
 	aFASTJavaStatement accept: self
 ]
 
+]
+
+{ #category : 'generated' }
+FASTJavaExportVisitor >> visitFASTJavaBooleanLiteral: aFASTJavaBooleanLiteral [
+	self checkForComments: aFASTJavaBooleanLiteral andDo: [
+		self visitFASTJavaLiteral: aFASTJavaBooleanLiteral
+	]
 ]
 
 { #category : 'visiting expression' }
@@ -335,10 +340,9 @@ FASTJavaExportVisitor >> visitFASTJavaCharTypeExpression: aFASTJavaCharTypeExpre
 FASTJavaExportVisitor >> visitFASTJavaCharacterLiteral: aFASTJavaCharacterLiteral [
 	self checkForComments: aFASTJavaCharacterLiteral andDo: [
 		self unindented: $'.
-		super visitFASTJavaCharacterLiteral: aFASTJavaCharacterLiteral.
+		self visitFASTJavaLiteral: aFASTJavaCharacterLiteral.
 		self unindented: $'
 	]
-
 ]
 
 { #category : 'visiting' }
@@ -535,6 +539,16 @@ FASTJavaExportVisitor >> visitFASTJavaEnumDeclaration: aFASTJavaEnumDeclaration 
 	]
 ]
 
+{ #category : 'visiting statement' }
+FASTJavaExportVisitor >> visitFASTJavaExpressionStatement: aFASTJavaExpressionStatement [
+
+	self checkForComments: aFASTJavaExpressionStatement andDo: [
+	  self indented: ''.
+	  aFASTJavaExpressionStatement expression accept: self.
+	  self endOfStatement
+	]
+]
+
 { #category : 'visiting expression' }
 FASTJavaExportVisitor >> visitFASTJavaFieldAccess: aFASTJavaFieldAccess [
 	self checkForComments: aFASTJavaFieldAccess andDo: [
@@ -552,9 +566,8 @@ FASTJavaExportVisitor >> visitFASTJavaFieldAccess: aFASTJavaFieldAccess [
 { #category : 'visiting expression' }
 FASTJavaExportVisitor >> visitFASTJavaFloatLiteral: aFASTJavaFloatLiteral [
 	self checkForComments: aFASTJavaFloatLiteral andDo: [
-		super visitFASTJavaFloatLiteral: aFASTJavaFloatLiteral
+		self visitFASTJavaLiteral: aFASTJavaFloatLiteral
 	]
-
 ]
 
 { #category : 'visiting expression' }
@@ -697,7 +710,7 @@ FASTJavaExportVisitor >> visitFASTJavaInitializer: aFASTJavaInitializer [
 
 	self indented: ''.
 	aFASTJavaInitializer isStatic ifTrue: [ self unindented: 'static ' ].
-	self visitFASTTStatementBlock: aFASTJavaInitializer statementBlock
+	self visitFASTJavaStatementBlock: aFASTJavaInitializer statementBlock
 ]
 
 { #category : 'visiting expression' }
@@ -706,6 +719,13 @@ FASTJavaExportVisitor >> visitFASTJavaIntTypeExpression: aFASTJavaIntTypeExpress
 	self unindented: 'int'
 ]
 
+]
+
+{ #category : 'visiting expression' }
+FASTJavaExportVisitor >> visitFASTJavaIntegerLiteral: aFASTJavaIntegerLiteral [
+	self checkForComments: aFASTJavaIntegerLiteral andDo: [
+		self visitFASTJavaLiteral: aFASTJavaIntegerLiteral
+	]
 ]
 
 { #category : 'visiting' }
@@ -768,9 +788,14 @@ FASTJavaExportVisitor >> visitFASTJavaLambdaExpression: aFASTJavaLambdaExpressio
 ]
 
 { #category : 'visiting expression' }
+FASTJavaExportVisitor >> visitFASTJavaLiteral: aFASTJavaLiteral [
+	self unindented: aFASTJavaLiteral primitiveValue
+]
+
+{ #category : 'visiting expression' }
 FASTJavaExportVisitor >> visitFASTJavaLongLiteral: aFASTJavaLongLiteral [
 	self checkForComments: aFASTJavaLongLiteral andDo: [
-		self visitFASTTLiteral: aFASTJavaLongLiteral
+		self visitFASTJavaLiteral: aFASTJavaLongLiteral
 	]
 ]
 
@@ -983,7 +1008,7 @@ FASTJavaExportVisitor >> visitFASTJavaPostfixedUnaryExpression: aFASTJavaUnaryEx
 
 	self
 		outputExpression: [
-			self visitFASTTExpression: aFASTJavaUnaryExpression.
+			aFASTJavaUnaryExpression expression accept: self.
 			self unindented: aFASTJavaUnaryExpression operator.
 			aFASTJavaUnaryExpression infixOperationLeftOperandOwner ifNotNil: [
 				self space ] ]
@@ -998,7 +1023,7 @@ FASTJavaExportVisitor >> visitFASTJavaPrefixedUnaryExpression: aFASTJavaUnaryExp
 			aFASTJavaUnaryExpression infixOperationRightOperandOwner ifNotNil: [
 				self space ].
 			self unindented: aFASTJavaUnaryExpression operator.
-			self visitFASTTExpression: aFASTJavaUnaryExpression ]
+			aFASTJavaUnaryExpression expression accept: self ]
 		withOperator: aFASTJavaUnaryExpression operator , 'unary'
 ]
 
@@ -1020,6 +1045,14 @@ FASTJavaExportVisitor >> visitFASTJavaQualifiedTypeName: aFASTJavaQualifiedTypeN
 
 ]
 
+{ #category : 'visiting statement' }
+FASTJavaExportVisitor >> visitFASTJavaReturnStatement: aFASTJavaReturnStatement [
+	self indented: 'return '.
+	aFASTJavaReturnStatement expression
+		ifNotNil: [ :returnedExpression | returnedExpression accept: self ].
+	self endOfStatement
+]
+
 { #category : 'visiting' }
 FASTJavaExportVisitor >> visitFASTJavaShortTypeExpression: aFASTJavaShortTypeExpression [
 	self checkForComments: aFASTJavaShortTypeExpression andDo: [
@@ -1039,14 +1072,28 @@ FASTJavaExportVisitor >> visitFASTJavaStatement: aFASTJavaStatement [
 
 ]
 
+{ #category : 'visiting statement' }
+FASTJavaExportVisitor >> visitFASTJavaStatementBlock: aFASTJavaStatementBlock [
+	self outputTopLevelExpression: [
+		self unindented: ${.
+		self newLine.
+		self indent.
+		aFASTJavaStatementBlock statements do: [ :node |
+			node accept: self
+		].
+		self unindent.
+		self indented: $}.
+		self newLine
+	]
+]
+
 { #category : 'visiting expression' }
 FASTJavaExportVisitor >> visitFASTJavaStringLiteral: aFASTJavaStringLiteral [
 	self checkForComments: aFASTJavaStringLiteral andDo: [
 		self unindented: $".
-		super visitFASTJavaStringLiteral: aFASTJavaStringLiteral.
+		self visitFASTJavaLiteral: aFASTJavaStringLiteral.
 		self unindented: $"
 	]
-
 ]
 
 { #category : 'visiting statement' }
@@ -1213,44 +1260,6 @@ FASTJavaExportVisitor >> visitFASTJavaWhileStatement: aFASTJavaWhileStatement [
 		self unindent.
 ]
 
-]
-
-{ #category : 'visiting statement' }
-FASTJavaExportVisitor >> visitFASTTExpressionStatement: aFASTTExpressionStatement [
-
-	self checkForComments: aFASTTExpressionStatement andDo: [
-	  self indented: ''.
-	  aFASTTExpressionStatement expression accept: self.
-	  self endOfStatement
-	]
-]
-
-{ #category : 'visiting expression' }
-FASTJavaExportVisitor >> visitFASTTLiteral: aFASTTLiteral [
-	self unindented: aFASTTLiteral primitiveValue
-]
-
-{ #category : 'visiting statement' }
-FASTJavaExportVisitor >> visitFASTTReturnStatement: aFASTTReturnStatement [
-	self indented: 'return '.
-	aFASTTReturnStatement expression
-		ifNotNil: [ :returnedExpression | returnedExpression accept: self ].
-	self endOfStatement
-]
-
-{ #category : 'visiting statement' }
-FASTJavaExportVisitor >> visitFASTTStatementBlock: aFASTJavaStatementBlock [
-	self outputTopLevelExpression: [
-		self unindented: ${.
-		self newLine.
-		self indent.
-		aFASTJavaStatementBlock statements do: [ :node |
-			node accept: self
-		].
-		self unindent.
-		self indented: $}.
-		self newLine
-	]
 ]
 
 { #category : 'visiting' }

--- a/src/FAST-Java-Tools/FASTJavaLocalResolverVisitor.class.st
+++ b/src/FAST-Java-Tools/FASTJavaLocalResolverVisitor.class.st
@@ -42,6 +42,17 @@ FASTJavaLocalResolverVisitor >> visitFASTJavaParameter: aFASTJavaParameter [
 ]
 
 { #category : 'visiting' }
+FASTJavaLocalResolverVisitor >> visitFASTJavaStatementBlock: aFASTJavaStatementBlock [
+	scoper pushScope.
+
+	"visit order is important to ensure declarations are visited before statements"
+	(aFASTJavaStatementBlock statements sorted: [:a :b | a startPos < b startPos])
+		do: [ :node | node accept: self ].
+
+	^scoper popScope
+]
+
+{ #category : 'visiting' }
 FASTJavaLocalResolverVisitor >> visitFASTJavaVariableDeclarator: aFASTJavaVariableDeclarator [
 	"register a variable (structuralEntity) declaration into the current scope"
 
@@ -66,15 +77,4 @@ FASTJavaLocalResolverVisitor >> visitFASTTBehaviouralEntity: aFASTBehaviouralEnt
 
 	aFASTBehaviouralEntity parameters do: [ :param | param accept: self].
 	aFASTBehaviouralEntity statementBlock accept: self
-]
-
-{ #category : 'visiting' }
-FASTJavaLocalResolverVisitor >> visitFASTTStatementBlock: aFASTJavaStatementBlock [
-	scoper pushScope.
-
-	"visit order is important to ensure declarations are visited before statements"
-	(aFASTJavaStatementBlock statements sorted: [:a :b | a startPos < b startPos])
-		do: [ :node | node accept: self ].
-
-	^scoper popScope
 ]

--- a/src/FAST-Java-Visitor/FASTJavaAnnotation.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaAnnotation.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaAnnotation }
+Extension { #name : 'FASTJavaAnnotation' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaAnnotation >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaAnnotation: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaArrayAccess.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaArrayAccess.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaArrayAccess }
+Extension { #name : 'FASTJavaArrayAccess' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaArrayAccess >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaArrayAccess: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaArrayAnnotationElement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaArrayAnnotationElement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaArrayAnnotationElement }
+Extension { #name : 'FASTJavaArrayAnnotationElement' }
 
-{ #category : #'*FAST-Java-Visitor' }
+{ #category : '*FAST-Java-Visitor' }
 FASTJavaArrayAnnotationElement >> accept: aVisitor [
 	^ aVisitor visitFASTJavaArrayAnnotationElement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaArrayInitializer.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaArrayInitializer.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaArrayInitializer }
+Extension { #name : 'FASTJavaArrayInitializer' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaArrayInitializer >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaArrayInitializer: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaArrayTypeExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaArrayTypeExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaArrayTypeExpression }
+Extension { #name : 'FASTJavaArrayTypeExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaArrayTypeExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaArrayTypeExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaAssertStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaAssertStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaAssertStatement }
+Extension { #name : 'FASTJavaAssertStatement' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaAssertStatement >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaAssertStatement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaAssignmentExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaAssignmentExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaAssignmentExpression }
+Extension { #name : 'FASTJavaAssignmentExpression' }
 
-{ #category : #'*FAST-Java-Visitor' }
+{ #category : '*FAST-Java-Visitor' }
 FASTJavaAssignmentExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaAssignmentExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaBooleanLiteral.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaBooleanLiteral.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaBooleanLiteral }
+Extension { #name : 'FASTJavaBooleanLiteral' }
 
-{ #category : #'*FAST-Java-Visitor' }
+{ #category : '*FAST-Java-Visitor' }
 FASTJavaBooleanLiteral >> accept: aVisitor [
 	^ aVisitor visitFASTJavaBooleanLiteral: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaBooleanTypeExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaBooleanTypeExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaBooleanTypeExpression }
+Extension { #name : 'FASTJavaBooleanTypeExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaBooleanTypeExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaBooleanTypeExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaBreakStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaBreakStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaBreakStatement }
+Extension { #name : 'FASTJavaBreakStatement' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaBreakStatement >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaBreakStatement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaByteTypeExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaByteTypeExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaByteTypeExpression }
+Extension { #name : 'FASTJavaByteTypeExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaByteTypeExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaByteTypeExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaCaseStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaCaseStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaCaseStatement }
+Extension { #name : 'FASTJavaCaseStatement' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaCaseStatement >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaCaseStatement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaCastExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaCastExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaCastExpression }
+Extension { #name : 'FASTJavaCastExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaCastExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaCastExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaCatchPartStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaCatchPartStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaCatchPartStatement }
+Extension { #name : 'FASTJavaCatchPartStatement' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaCatchPartStatement >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaCatchPartStatement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaCharTypeExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaCharTypeExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaCharTypeExpression }
+Extension { #name : 'FASTJavaCharTypeExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaCharTypeExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaCharTypeExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaCharacterLiteral.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaCharacterLiteral.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaCharacterLiteral }
+Extension { #name : 'FASTJavaCharacterLiteral' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaCharacterLiteral >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaCharacterLiteral: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaClassDeclaration.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaClassDeclaration.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaClassDeclaration }
+Extension { #name : 'FASTJavaClassDeclaration' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaClassDeclaration >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaClassDeclaration: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaClassProperty.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaClassProperty.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaClassProperty }
+Extension { #name : 'FASTJavaClassProperty' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaClassProperty >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaClassProperty: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaClassTypeExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaClassTypeExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaClassTypeExpression }
+Extension { #name : 'FASTJavaClassTypeExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaClassTypeExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaClassTypeExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaCompilationUnit.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaCompilationUnit.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaCompilationUnit }
+Extension { #name : 'FASTJavaCompilationUnit' }
 
-{ #category : #'*FAST-Java-Visitor' }
+{ #category : '*FAST-Java-Visitor' }
 FASTJavaCompilationUnit >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaCompilationUnit: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaConditionalExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaConditionalExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaConditionalExpression }
+Extension { #name : 'FASTJavaConditionalExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaConditionalExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaConditionalExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaContinueStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaContinueStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaContinueStatement }
+Extension { #name : 'FASTJavaContinueStatement' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaContinueStatement >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaContinueStatement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaDefaultCaseStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaDefaultCaseStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaDefaultCaseStatement }
+Extension { #name : 'FASTJavaDefaultCaseStatement' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaDefaultCaseStatement >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaDefaultCaseStatement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaDoWhileStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaDoWhileStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaDoWhileStatement }
+Extension { #name : 'FASTJavaDoWhileStatement' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaDoWhileStatement >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaDoWhileStatement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaDoubleLiteral.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaDoubleLiteral.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaDoubleLiteral }
+Extension { #name : 'FASTJavaDoubleLiteral' }
 
-{ #category : #'*FAST-Java-Visitor' }
+{ #category : '*FAST-Java-Visitor' }
 FASTJavaDoubleLiteral >> accept: aVisitor [
 	^ aVisitor visitFASTJavaDoubleLiteral: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaDoubleTypeExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaDoubleTypeExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaDoubleTypeExpression }
+Extension { #name : 'FASTJavaDoubleTypeExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaDoubleTypeExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaDoubleTypeExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaEmptyDimExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaEmptyDimExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaEmptyDimExpression }
+Extension { #name : 'FASTJavaEmptyDimExpression' }
 
-{ #category : #'*FAST-Java-Visitor' }
+{ #category : '*FAST-Java-Visitor' }
 FASTJavaEmptyDimExpression >> accept: aVisitor [
 	^ aVisitor visitFASTJavaEmptyDimExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaEmptyMethodDeclaration.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaEmptyMethodDeclaration.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaEmptyMethodDeclaration }
+Extension { #name : 'FASTJavaEmptyMethodDeclaration' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaEmptyMethodDeclaration >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaEmptyMethodDeclaration: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaEnumConstant.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaEnumConstant.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaEnumConstant }
+Extension { #name : 'FASTJavaEnumConstant' }
 
-{ #category : #'*FAST-Java-Visitor' }
+{ #category : '*FAST-Java-Visitor' }
 FASTJavaEnumConstant >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaEnumConstant: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaEnumDeclaration.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaEnumDeclaration.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaEnumDeclaration }
+Extension { #name : 'FASTJavaEnumDeclaration' }
 
-{ #category : #'*FAST-Java-Visitor' }
+{ #category : '*FAST-Java-Visitor' }
 FASTJavaEnumDeclaration >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaEnumDeclaration: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaExpressionStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaExpressionStatement.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'FASTJavaExpressionStatement' }
+
+{ #category : '*FAST-Java-Visitor' }
+FASTJavaExpressionStatement >> accept: aFASTJavaVisitor [
+	^ aFASTJavaVisitor visitFASTJavaExpressionStatement: self
+]

--- a/src/FAST-Java-Visitor/FASTJavaFieldAccess.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaFieldAccess.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaFieldAccess }
+Extension { #name : 'FASTJavaFieldAccess' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaFieldAccess >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaFieldAccess: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaFloatLiteral.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaFloatLiteral.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaFloatLiteral }
+Extension { #name : 'FASTJavaFloatLiteral' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaFloatLiteral >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaFloatLiteral: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaFloatTypeExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaFloatTypeExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaFloatTypeExpression }
+Extension { #name : 'FASTJavaFloatTypeExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaFloatTypeExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaFloatTypeExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaForEachStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaForEachStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaForEachStatement }
+Extension { #name : 'FASTJavaForEachStatement' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaForEachStatement >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaForEachStatement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaForStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaForStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaForStatement }
+Extension { #name : 'FASTJavaForStatement' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaForStatement >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaForStatement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaIdentifier.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaIdentifier.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaIdentifier }
+Extension { #name : 'FASTJavaIdentifier' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaIdentifier >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaIdentifier: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaIfStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaIfStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaIfStatement }
+Extension { #name : 'FASTJavaIfStatement' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaIfStatement >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaIfStatement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaImportDeclaration.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaImportDeclaration.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaImportDeclaration }
+Extension { #name : 'FASTJavaImportDeclaration' }
 
-{ #category : #'*FAST-Java-Visitor' }
+{ #category : '*FAST-Java-Visitor' }
 FASTJavaImportDeclaration >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaImportDeclaration: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaInfixOperation.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaInfixOperation.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaInfixOperation }
+Extension { #name : 'FASTJavaInfixOperation' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaInfixOperation >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaInfixOperation: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaInitializer.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaInitializer.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaInitializer }
+Extension { #name : 'FASTJavaInitializer' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaInitializer >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaInitializer: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaIntTypeExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaIntTypeExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaIntTypeExpression }
+Extension { #name : 'FASTJavaIntTypeExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaIntTypeExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaIntTypeExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaIntegerLiteral.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaIntegerLiteral.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaIntegerLiteral }
+Extension { #name : 'FASTJavaIntegerLiteral' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaIntegerLiteral >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaIntegerLiteral: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaInterfaceDeclaration.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaInterfaceDeclaration.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaInterfaceDeclaration }
+Extension { #name : 'FASTJavaInterfaceDeclaration' }
 
-{ #category : #'*FAST-Java-Visitor' }
+{ #category : '*FAST-Java-Visitor' }
 FASTJavaInterfaceDeclaration >> accept: aFASTJavaVisitor [ 
 	^ aFASTJavaVisitor visitFASTJavaInterfaceDeclaration: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaLabeledCaseStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaLabeledCaseStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaLabeledCaseStatement }
+Extension { #name : 'FASTJavaLabeledCaseStatement' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaLabeledCaseStatement >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaLabeledCaseStatement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaLabeledStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaLabeledStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaLabeledStatement }
+Extension { #name : 'FASTJavaLabeledStatement' }
 
-{ #category : #'*FAST-Java-Visitor' }
+{ #category : '*FAST-Java-Visitor' }
 FASTJavaLabeledStatement >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaLabeledStatement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaLambdaExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaLambdaExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaLambdaExpression }
+Extension { #name : 'FASTJavaLambdaExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaLambdaExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaLambdaExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaLongLiteral.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaLongLiteral.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaLongLiteral }
+Extension { #name : 'FASTJavaLongLiteral' }
 
-{ #category : #'*FAST-Java-Visitor' }
+{ #category : '*FAST-Java-Visitor' }
 FASTJavaLongLiteral >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaLongLiteral: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaLongTypeExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaLongTypeExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaLongTypeExpression }
+Extension { #name : 'FASTJavaLongTypeExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaLongTypeExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaLongTypeExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaMethodEntity.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaMethodEntity.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaMethodEntity }
+Extension { #name : 'FASTJavaMethodEntity' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaMethodEntity >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaMethodEntity: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaMethodInvocation.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaMethodInvocation.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaMethodInvocation }
+Extension { #name : 'FASTJavaMethodInvocation' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaMethodInvocation >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaMethodInvocation: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaMethodReference.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaMethodReference.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaMethodReference }
+Extension { #name : 'FASTJavaMethodReference' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaMethodReference >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaMethodReference: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaModifier.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaModifier.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaModifier }
+Extension { #name : 'FASTJavaModifier' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaModifier >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaModifier: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaNewArray.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaNewArray.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaNewArray }
+Extension { #name : 'FASTJavaNewArray' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaNewArray >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaNewArray: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaNewClassExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaNewClassExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaNewClassExpression }
+Extension { #name : 'FASTJavaNewClassExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaNewClassExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaNewClassExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaNewExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaNewExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaNewExpression }
+Extension { #name : 'FASTJavaNewExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaNewExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaNewExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaNullLiteral.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaNullLiteral.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaNullLiteral }
+Extension { #name : 'FASTJavaNullLiteral' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaNullLiteral >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaNullLiteral: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaOuterThis.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaOuterThis.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaOuterThis }
+Extension { #name : 'FASTJavaOuterThis' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaOuterThis >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaOuterThis: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaPackageDeclaration.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaPackageDeclaration.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaPackageDeclaration }
+Extension { #name : 'FASTJavaPackageDeclaration' }
 
-{ #category : #'*FAST-Java-Visitor' }
+{ #category : '*FAST-Java-Visitor' }
 FASTJavaPackageDeclaration >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaPackageDeclaration: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaParameter.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaParameter.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaParameter }
+Extension { #name : 'FASTJavaParameter' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaParameter >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaParameter: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaPrimitiveTypeExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaPrimitiveTypeExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaPrimitiveTypeExpression }
+Extension { #name : 'FASTJavaPrimitiveTypeExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaPrimitiveTypeExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaPrimitiveTypeExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaQualifiedName.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaQualifiedName.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaQualifiedName }
+Extension { #name : 'FASTJavaQualifiedName' }
 
-{ #category : #'*FAST-Java-Visitor' }
+{ #category : '*FAST-Java-Visitor' }
 FASTJavaQualifiedName >> accept: aFASTJavaVisitor [ 
 	^ aFASTJavaVisitor visitFASTJavaQualifiedName: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaQualifiedTypeName.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaQualifiedTypeName.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaQualifiedTypeName }
+Extension { #name : 'FASTJavaQualifiedTypeName' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaQualifiedTypeName >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaQualifiedTypeName: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaReturnStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaReturnStatement.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'FASTJavaReturnStatement' }
+
+{ #category : '*FAST-Java-Visitor' }
+FASTJavaReturnStatement >> accept: aFASTJavaVisitor [
+	^ aFASTJavaVisitor visitFASTJavaReturnStatement: self
+]

--- a/src/FAST-Java-Visitor/FASTJavaShortTypeExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaShortTypeExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaShortTypeExpression }
+Extension { #name : 'FASTJavaShortTypeExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaShortTypeExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaShortTypeExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaStatement }
+Extension { #name : 'FASTJavaStatement' }
 
-{ #category : #'*FAST-Java-Visitor' }
+{ #category : '*FAST-Java-Visitor' }
 FASTJavaStatement >> accept: aVisitor [
 	^ aVisitor visitFASTJavaStatement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaStatementBlock.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaStatementBlock.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'FASTJavaStatementBlock' }
+
+{ #category : '*FAST-Java-Visitor' }
+FASTJavaStatementBlock >> accept: aFASTJavaVisitor [
+	^ aFASTJavaVisitor visitFASTJavaStatementBlock: self
+]

--- a/src/FAST-Java-Visitor/FASTJavaStringLiteral.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaStringLiteral.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaStringLiteral }
+Extension { #name : 'FASTJavaStringLiteral' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaStringLiteral >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaStringLiteral: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaSwitchStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaSwitchStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaSwitchStatement }
+Extension { #name : 'FASTJavaSwitchStatement' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaSwitchStatement >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaSwitchStatement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaSynchronizedStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaSynchronizedStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaSynchronizedStatement }
+Extension { #name : 'FASTJavaSynchronizedStatement' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaSynchronizedStatement >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaSynchronizedStatement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaThis.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaThis.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaThis }
+Extension { #name : 'FASTJavaThis' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaThis >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaThis: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaThrowStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaThrowStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaThrowStatement }
+Extension { #name : 'FASTJavaThrowStatement' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaThrowStatement >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaThrowStatement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaTryCatchStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaTryCatchStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaTryCatchStatement }
+Extension { #name : 'FASTJavaTryCatchStatement' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaTryCatchStatement >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaTryCatchStatement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaTypeExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaTypeExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaTypeExpression }
+Extension { #name : 'FASTJavaTypeExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaTypeExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaTypeExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaTypeName.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaTypeName.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaTypeName }
+Extension { #name : 'FASTJavaTypeName' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaTypeName >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaTypeName: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaTypeParameterExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaTypeParameterExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaTypeParameterExpression }
+Extension { #name : 'FASTJavaTypeParameterExpression' }
 
-{ #category : #'*FAST-Java-Visitor' }
+{ #category : '*FAST-Java-Visitor' }
 FASTJavaTypeParameterExpression >> accept: aVisitor [
 	^ aVisitor visitFASTJavaTypeParameter: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaTypePattern.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaTypePattern.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'FASTJavaTypePattern' }
+
+{ #category : '*FAST-Java-Visitor' }
+FASTJavaTypePattern >> accept: aFASTJavaVisitor [
+	^ aFASTJavaVisitor visitFASTJavaTypePattern: self
+]

--- a/src/FAST-Java-Visitor/FASTJavaUnaryExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaUnaryExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaUnaryExpression }
+Extension { #name : 'FASTJavaUnaryExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaUnaryExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaUnaryExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaVarDeclStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaVarDeclStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaVarDeclStatement }
+Extension { #name : 'FASTJavaVarDeclStatement' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaVarDeclStatement >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaVarDeclStatement: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaVarTypeExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaVarTypeExpression.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : 'FASTJavaVarTypeExpression' }
+
+{ #category : '*FAST-Java-Visitor' }
+FASTJavaVarTypeExpression >> accept: aFASTJavaVisitor [
+	^ aFASTJavaVisitor visitFASTJavaVarTypeExpression: self
+]

--- a/src/FAST-Java-Visitor/FASTJavaVariableDeclarator.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaVariableDeclarator.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaVariableDeclarator }
+Extension { #name : 'FASTJavaVariableDeclarator' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaVariableDeclarator >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaVariableDeclarator: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaVariableExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaVariableExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaVariableExpression }
+Extension { #name : 'FASTJavaVariableExpression' }
 
-{ #category : #'*FAST-Java-Visitor' }
+{ #category : '*FAST-Java-Visitor' }
 FASTJavaVariableExpression >> accept: aVisitor [
 	^ aVisitor visitFASTJavaVariableExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaVisitor.class.st
+++ b/src/FAST-Java-Visitor/FASTJavaVisitor.class.st
@@ -1,457 +1,488 @@
 Class {
-	#name : #FASTJavaVisitor,
-	#superclass : #FASTCoreVisitor,
-	#category : #'FAST-Java-Visitor'
+	#name : 'FASTJavaVisitor',
+	#superclass : 'FASTCoreVisitor',
+	#category : 'FAST-Java-Visitor',
+	#package : 'FAST-Java-Visitor'
 }
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaAnnotation: aFASTJavaAnnotation [
 	^ self visitFASTTExpression: aFASTJavaAnnotation
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaArrayAccess: aFASTJavaArrayAccess [
 	^ self visitFASTTExpression: aFASTJavaArrayAccess
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaArrayAnnotationElement: aFASTJavaArrayAnnotationElement [
 	^ self visitFASTTExpression: aFASTJavaArrayAnnotationElement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaArrayInitializer: aFASTJavaArrayInitializer [
 	^ self visitFASTTExpression: aFASTJavaArrayInitializer
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaArrayTypeExpression: aFASTJavaArrayTypeExpression [
 	^ self visitFASTJavaTypeExpression: aFASTJavaArrayTypeExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaAssertStatement: aFASTJavaAssertStatement [
 	^ self visitFASTTStatement: aFASTJavaAssertStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaAssignmentExpression: aFASTJavaAssignmentExpression [
 	^ self visitFASTTExpression: aFASTJavaAssignmentExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaBodyStatement: aFASTJavaBodyStatement [
 	^ self visitFASTTStatement: aFASTJavaBodyStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaBooleanLiteral: aFASTJavaBooleanLiteral [
 	^ self visitFASTTBooleanLiteral: aFASTJavaBooleanLiteral
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaBooleanTypeExpression: aFASTJavaBooleanTypeExpression [
 	^ self visitFASTJavaPrimitiveTypeExpression: aFASTJavaBooleanTypeExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaBreakStatement: aFASTJavaBreakStatement [
 	^ self visitFASTTStatement: aFASTJavaBreakStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaByteTypeExpression: aFASTJavaByteTypeExpression [
 	^ self visitFASTJavaPrimitiveTypeExpression: aFASTJavaByteTypeExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaCaseStatement: aFASTJavaCaseStatement [
 	^ self visitFASTTStatementBlock: aFASTJavaCaseStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaCastExpression: aFASTJavaCastExpression [
 	^ self visitFASTTExpression: aFASTJavaCastExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaCatchPartStatement: aFASTJavaCatchPartStatement [
 	^ self visitFASTTStatement: aFASTJavaCatchPartStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaCharTypeExpression: aFASTJavaCharTypeExpression [
 	^ self visitFASTJavaPrimitiveTypeExpression: aFASTJavaCharTypeExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaCharacterLiteral: aFASTJavaCharacterLiteral [
 	^ self visitFASTTCharacterLiteral: aFASTJavaCharacterLiteral
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaClassDeclaration: aFASTJavaClassDeclaration [
 	^ self visitFASTTStatement: aFASTJavaClassDeclaration
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaClassProperty: aFASTJavaClassProperty [
 	^ self visitFASTTVariableExpression: aFASTJavaClassProperty
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaClassTypeExpression: aFASTJavaClassTypeExpression [
 	^ self visitFASTJavaTypeExpression: aFASTJavaClassTypeExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaCompilationUnit: aFASTJavaCompilationUnit [
 
 	^ self visitFASTTEntity: aFASTJavaCompilationUnit
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaConditionStatement: aFASTJavaConditionStatement [
 	^ self visitFASTTStatement: aFASTJavaConditionStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaConditionalExpression: aFASTJavaConditionalExpression [
 	^ self visitFASTTExpression: aFASTJavaConditionalExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaConditionalStatement: aFASTJavaConditionalStatement [
 	^ self visitFASTTStatement: aFASTJavaConditionalStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaContinueStatement: aFASTJavaContinueStatement [
 	^ self visitFASTTStatement: aFASTJavaContinueStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaDefaultCaseStatement: aFASTJavaDefaultCaseStatement [
 	^ self visitFASTJavaCaseStatement: aFASTJavaDefaultCaseStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaDoWhileStatement: aFASTJavaDoWhileStatement [
 	^ self visitFASTTStatement: aFASTJavaDoWhileStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaDoubleLiteral: aFASTJavaDoubleLiteral [
 	^ self visitFASTTLiteral: aFASTJavaDoubleLiteral
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaDoubleTypeExpression: aFASTJavaDoubleTypeExpression [
 	^ self visitFASTJavaPrimitiveTypeExpression: aFASTJavaDoubleTypeExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaElsePartStatement: aFASTJavaElsePartStatement [
 	^ self visitFASTTStatement: aFASTJavaElsePartStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaEmptyDimExpression: aFASTJavaAssignmentExpression [
 	^ self visitFASTTExpression: aFASTJavaAssignmentExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaEmptyMethodDeclaration: aFASTJavaEmptyMethodDeclaration [
 	^ self visitFASTJavaMethodEntity: aFASTJavaEmptyMethodDeclaration
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaEnumConstant: aFASTJavaEnumConstant [
 	^ self visitFASTTVariableExpression: aFASTJavaEnumConstant
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaEnumDeclaration: aFASTJavaEnumDeclaration [
 	^ self visitFASTTStatement: aFASTJavaEnumDeclaration
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
+FASTJavaVisitor >> visitFASTJavaExpressionStatement: aFASTJavaExpressionStatement [
+	^ self visitFASTTExpressionStatement: aFASTJavaExpressionStatement
+]
+
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaFieldAccess: aFASTJavaFieldAccess [
 	^ self visitFASTTExpression: aFASTJavaFieldAccess
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaFloatLiteral: aFASTJavaFloatLiteral [
 	^ self visitFASTTLiteral: aFASTJavaFloatLiteral
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaFloatTypeExpression: aFASTJavaFloatTypeExpression [
 	^ self visitFASTJavaPrimitiveTypeExpression: aFASTJavaFloatTypeExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaForEachStatement: aFASTJavaForEachStatement [
 	^ self visitFASTTStatement: aFASTJavaForEachStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaForStatement: aFASTJavaForStatement [
 	^ self visitFASTTStatement: aFASTJavaForStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaIdentifier: aFASTJavaIdentifier [
 	^ self visitFASTTVariableExpression: aFASTJavaIdentifier
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaIfStatement: aFASTJavaIfStatement [
 	^ self visitFASTTStatement: aFASTJavaIfStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaImportDeclaration: aFASTJavaImportDeclaration [
 
 	^ self visitFASTTEntity: aFASTJavaImportDeclaration
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaIncrementorsStatement: aFASTJavaIncrementorsStatement [
 	^ self visitFASTTStatement: aFASTJavaIncrementorsStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaInfixOperation: aFASTJavaInfixOperation [
 	^ self visitFASTTExpression: aFASTJavaInfixOperation
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaInitializer: aFASTJavaInitializer [
 	^ self visitFASTTScopableEntity: aFASTJavaInitializer
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaInitializersStatement: aFASTJavaInitializersStatement [
 	^ self visitFASTTStatement: aFASTJavaInitializersStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaIntTypeExpression: aFASTJavaIntTypeExpression [
 	^ self visitFASTJavaPrimitiveTypeExpression: aFASTJavaIntTypeExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaIntegerLiteral: aFASTJavaIntegerLiteral [
 	^ self visitFASTTLiteral: aFASTJavaIntegerLiteral
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaInterfaceDeclaration: aFASTJavaInterfaceDeclaration [
 	^ self visitFASTTStatement: aFASTJavaInterfaceDeclaration
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaLabeledCaseStatement: aFASTJavaLabeledCaseStatement [
 	^ self visitFASTJavaCaseStatement: aFASTJavaLabeledCaseStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaLabeledStatement: aFASTJavaLabeledStatement [
 	^ self visitFASTTStatement: aFASTJavaLabeledStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaLambdaExpression: aFASTJavaLambdaExpression [
 	^ self visitFASTTExpression: aFASTJavaLambdaExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
+FASTJavaVisitor >> visitFASTJavaLiteral: aFASTJavaLiteral [
+	^ self visitFASTTLiteral: aFASTJavaLiteral
+]
+
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaLongTypeExpression: aFASTJavaLongTypeExpression [
 	^ self visitFASTJavaPrimitiveTypeExpression: aFASTJavaLongTypeExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaMethodEntity: aFASTJavaMethodEntity [
 	^ self visitFASTTNamedBehaviouralEntity: aFASTJavaMethodEntity
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaMethodInvocation: aFASTJavaMethodInvocation [
 	^ self visitFASTTExpression: aFASTJavaMethodInvocation
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaMethodReference: aFASTJavaMethodReference [
 	^ self visitFASTTVariableExpression: aFASTJavaMethodReference
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaModifier: aFASTJavaModifier [
 	^ self visitFASTTExpression: aFASTJavaModifier
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaNewArray: aFASTJavaNewArray [
 	^ self visitFASTJavaNewExpression: aFASTJavaNewArray
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaNewClassExpression: aFASTJavaNewClassExpression [
 	^ self visitFASTJavaNewExpression: aFASTJavaNewClassExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaNewClassMethodStatment: aFASTJavaNewClassMethodStatment [
 	^ self visitFASTTStatement: aFASTJavaNewClassMethodStatment
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaNewExpression: aFASTJavaNewExpression [
 	^ self visitFASTTExpression: aFASTJavaNewExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaNullLiteral: aFASTJavaNullLiteral [
 	^ self visitFASTTNullPointerLiteral: aFASTJavaNullLiteral
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaOperationLeftOperand: aFASTJavaOperationLeftOperand [
 	^ self visitFASTTExpression: aFASTJavaOperationLeftOperand
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaOperationRightOperand: aFASTJavaOperationRightOperand [
 	^ self visitFASTTExpression: aFASTJavaOperationRightOperand
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaOuterThis: aFASTJavaOuterThis [
 	^ self visitFASTTExpression: aFASTJavaOuterThis
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaPackageDeclaration: aFASTJavaPackageDeclaration [ 
 	^ self visitFASTTEntity: aFASTJavaPackageDeclaration
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaParameter: aFASTJavaParameter [
 	^ self visitFASTTVariableExpression: aFASTJavaParameter
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaPrimitiveTypeExpression: aFASTJavaPrimitiveTypeExpression [
 	^ self visitFASTJavaTypeExpression: aFASTJavaPrimitiveTypeExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaQualifiedName: aFASTJavaQualifiedName [
 	^ self visitFASTTEntity: aFASTJavaQualifiedName
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaQualifiedTypeName: aFASTJavaQualifiedTypeName [
 	^ self visitFASTJavaTypeName: aFASTJavaQualifiedTypeName
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
+FASTJavaVisitor >> visitFASTJavaReturnStatement: aFASTJavaReturnStatement [
+	^ self visitFASTTReturnStatement: aFASTJavaReturnStatement
+]
+
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaSeparator: aFASTJavaSeparator [
 	^ self visitFASTTVariableExpression: aFASTJavaSeparator
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaShortTypeExpression: aFASTJavaShortTypeExpression [
 	^ self visitFASTJavaPrimitiveTypeExpression: aFASTJavaShortTypeExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaStatement: aFASTJavaStatement [
 	^ self visitFASTTEntity: aFASTJavaStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
+FASTJavaVisitor >> visitFASTJavaStatementBlock: aFASTJavaStatementBlock [
+	^ self visitFASTTStatementBlock: aFASTJavaStatementBlock
+]
+
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaStringLiteral: aFASTJavaStringLiteral [
 	^ self visitFASTTStringLiteral: aFASTJavaStringLiteral
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaSwitchStatement: aFASTJavaSwitchStatement [
 	^ self visitFASTTStatement: aFASTJavaSwitchStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaSynchronizedStatement: aFASTJavaSynchronizedStatement [
 	^ self visitFASTTStatement: aFASTJavaSynchronizedStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaThenPartStatement: aFASTJavaThenPartStatement [
 	^ self visitFASTTStatement: aFASTJavaThenPartStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaThis: aFASTJavaThis [
 	^ self visitFASTTVariableExpression: aFASTJavaThis
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaThrowStatement: aFASTJavaThrowStatement [
 	^ self visitFASTTStatement: aFASTJavaThrowStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaTryCatchStatement: aFASTJavaTryCatchStatement [
 	^ self visitFASTTStatement: aFASTJavaTryCatchStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaTryPartStatement: aFASTJavaTryPartStatement [
 	^ self visitFASTTStatement: aFASTJavaTryPartStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaTypeExpression: aFASTJavaTypeExpression [
 	^ self visitFASTTVariableExpression: aFASTJavaTypeExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaTypeName: aFASTJavaTypeName [
 	^ self visitFASTTExpression: aFASTJavaTypeName
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaTypeParameter: aFASTJavaTypeParameterExpression [
 	^ self visitFASTTExpression: aFASTJavaTypeParameterExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
+FASTJavaVisitor >> visitFASTJavaTypePattern: aFASTJavaTypePattern [
+	^ self visitFASTTExpression: aFASTJavaTypePattern
+]
+
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaUnaryExpression: aFASTJavaUnaryExpression [
 	^ self visitFASTTExpression: aFASTJavaUnaryExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaVarDeclStatement: aFASTJavaVarDeclStatement [
 	^ self visitFASTTStatement: aFASTJavaVarDeclStatement
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
+FASTJavaVisitor >> visitFASTJavaVarTypeExpression: aFASTJavaVarTypeExpression [
+	^ self visitFASTTVariableExpression: aFASTJavaVarTypeExpression
+]
+
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaVariableDeclarator: aFASTJavaVariableDeclarator [
 	^ self visitFASTEntity: aFASTJavaVariableDeclarator
 ]
 
-{ #category : #'visiting expression' }
+{ #category : 'visiting expression' }
 FASTJavaVisitor >> visitFASTJavaVariableExpression: aFASTJavaVariableExpression [
 	^ self visitFASTTVariableExpression: aFASTJavaVariableExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaVoidTypeExpression: aFASTJavaVoidTypeExpression [
 	^ self visitFASTJavaPrimitiveTypeExpression: aFASTJavaVoidTypeExpression
 ]
 
-{ #category : #generated }
+{ #category : 'generated' }
 FASTJavaVisitor >> visitFASTJavaWhileStatement: aFASTJavaWhileStatement [
 	^ self visitFASTTStatement: aFASTJavaWhileStatement
 ]

--- a/src/FAST-Java-Visitor/FASTJavaVoidTypeExpression.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaVoidTypeExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaVoidTypeExpression }
+Extension { #name : 'FASTJavaVoidTypeExpression' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaVoidTypeExpression >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaVoidTypeExpression: self
 ]

--- a/src/FAST-Java-Visitor/FASTJavaWhileStatement.extension.st
+++ b/src/FAST-Java-Visitor/FASTJavaWhileStatement.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaWhileStatement }
+Extension { #name : 'FASTJavaWhileStatement' }
 
-{ #category : #'*FAST-Java-Visitor-generated' }
+{ #category : '*FAST-Java-Visitor-generated' }
 FASTJavaWhileStatement >> accept: aFASTJavaVisitor [
 	^ aFASTJavaVisitor visitFASTJavaWhileStatement: self
 ]

--- a/src/FAST-Java-Visitor/package.st
+++ b/src/FAST-Java-Visitor/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'FAST-Java-Visitor' }
+Package { #name : 'FAST-Java-Visitor' }


### PR DESCRIPTION
`TEntityMetaLevelDependency >> children` has been [deprecated](https://github.com/moosetechnology/Famix/pull/1036) in favor of `containedEntities`.

Plus FASTJavaEntity had an extension in FAST-Java-Model, which is where FASTJavaEntity is defined (was that possible?), and it's a duplicate: the method already exists in FAST-Java-Model-Extension.

~~All in all, this is just a bit of cleanup.~~
At least it was supposed to be a simple cleanup job, but I also had to repair visitors that were broken by moosetechnology/FAST#122