### PR TITLE
fix(Sources): CompilationUnit w/ source + Recursive lookup

### DIFF
--- a/src/FAST-Java-Model-Extension/FASTJavaClassDeclaration.extension.st
+++ b/src/FAST-Java-Model-Extension/FASTJavaClassDeclaration.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'FASTJavaClassDeclaration' }
+
+{ #category : '*FAST-Java-Model-Extension' }
+FASTJavaClassDeclaration >> sourceText [
+
+	^ self source ifNil: [ self parentNode ifNil: [ '' ] ifNotNil: [ :parentNode | parentNode sourceText ] ]
+]

--- a/src/FAST-Java-Model-Extension/FASTJavaClassTypeExpression.extension.st
+++ b/src/FAST-Java-Model-Extension/FASTJavaClassTypeExpression.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaClassTypeExpression }
+Extension { #name : 'FASTJavaClassTypeExpression' }
 
-{ #category : #'*FAST-Java-Model-Extension' }
+{ #category : '*FAST-Java-Model-Extension' }
 FASTJavaClassTypeExpression >> fullName [
 	^ typeName fullName
 ]

--- a/src/FAST-Java-Model-Extension/FASTJavaComment.extension.st
+++ b/src/FAST-Java-Model-Extension/FASTJavaComment.extension.st
@@ -1,16 +1,16 @@
-Extension { #name : #FASTJavaComment }
+Extension { #name : 'FASTJavaComment' }
 
-{ #category : #'*FAST-Java-Model-Extension' }
+{ #category : '*FAST-Java-Model-Extension' }
 FASTJavaComment >> isBlockComment [
 	^self content beginsWith: '/*'
 ]
 
-{ #category : #'*FAST-Java-Model-Extension' }
+{ #category : '*FAST-Java-Model-Extension' }
 FASTJavaComment >> isJavadocComment [
 	^self content beginsWith: '/**'
 ]
 
-{ #category : #'*FAST-Java-Model-Extension' }
+{ #category : '*FAST-Java-Model-Extension' }
 FASTJavaComment >> isLineComment [
 	^self content beginsWith: '//'
 ]

--- a/src/FAST-Java-Model-Extension/FASTJavaCompilationUnit.extension.st
+++ b/src/FAST-Java-Model-Extension/FASTJavaCompilationUnit.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'FASTJavaCompilationUnit' }
+
+{ #category : '*FAST-Java-Model-Extension' }
+FASTJavaCompilationUnit >> sourceText [
+
+	^ self source ifNil: [ '' ]
+]

--- a/src/FAST-Java-Model-Extension/FASTJavaEntity.extension.st
+++ b/src/FAST-Java-Model-Extension/FASTJavaEntity.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaEntity }
+Extension { #name : 'FASTJavaEntity' }
 
-{ #category : #'*FAST-Java-Model-Extension' }
+{ #category : '*FAST-Java-Model-Extension' }
 FASTJavaEntity >> exporterClassName [
 
 	^ #FASTJavaExportVisitor

--- a/src/FAST-Java-Model-Extension/FASTJavaEnumDeclaration.extension.st
+++ b/src/FAST-Java-Model-Extension/FASTJavaEnumDeclaration.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'FASTJavaEnumDeclaration' }
+
+{ #category : '*FAST-Java-Model-Extension' }
+FASTJavaEnumDeclaration >> sourceText [
+
+	^ self source ifNil: [ self parentNode ifNil: [ '' ] ifNotNil: [ :parentNode | parentNode sourceText ] ]
+]

--- a/src/FAST-Java-Model-Extension/FASTJavaImportDeclaration.extension.st
+++ b/src/FAST-Java-Model-Extension/FASTJavaImportDeclaration.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaImportDeclaration }
+Extension { #name : 'FASTJavaImportDeclaration' }
 
-{ #category : #'*FAST-Java-Model-Extension' }
+{ #category : '*FAST-Java-Model-Extension' }
 FASTJavaImportDeclaration >> declarationName [
 
 	self
@@ -10,7 +10,7 @@ FASTJavaImportDeclaration >> declarationName [
 	^ self qualifiedName
 ]
 
-{ #category : #'*FAST-Java-Model-Extension' }
+{ #category : '*FAST-Java-Model-Extension' }
 FASTJavaImportDeclaration >> declarationName: aName [
 
 	self

--- a/src/FAST-Java-Model-Extension/FASTJavaInitializer.extension.st
+++ b/src/FAST-Java-Model-Extension/FASTJavaInitializer.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'FASTJavaInitializer' }
+
+{ #category : '*FAST-Java-Model-Extension' }
+FASTJavaInitializer >> sourceText [
+
+	^ self source ifNil: [ self parentNode ifNil: [ '' ] ifNotNil: [ :parentNode | parentNode sourceText ] ]
+]

--- a/src/FAST-Java-Model-Extension/FASTJavaInterfaceDeclaration.extension.st
+++ b/src/FAST-Java-Model-Extension/FASTJavaInterfaceDeclaration.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'FASTJavaInterfaceDeclaration' }
+
+{ #category : '*FAST-Java-Model-Extension' }
+FASTJavaInterfaceDeclaration >> sourceText [
+
+	^ self source ifNil: [ self parentNode ifNil: [ '' ] ifNotNil: [ :parentNode | parentNode sourceText ] ]
+]

--- a/src/FAST-Java-Model-Extension/FASTJavaMethodEntity.extension.st
+++ b/src/FAST-Java-Model-Extension/FASTJavaMethodEntity.extension.st
@@ -1,12 +1,12 @@
-Extension { #name : #FASTJavaMethodEntity }
+Extension { #name : 'FASTJavaMethodEntity' }
 
-{ #category : #'*FAST-Java-Model-Extension' }
+{ #category : '*FAST-Java-Model-Extension' }
 FASTJavaMethodEntity >> sourceText [
 
-	^ self source ifNil: [ self parentNode ifNil: [ '' ] ifNotNil: [ :existingParentNode | existingParentNode sourceText ] ]
+	^ self source ifNil: [ self parentNode ifNil: [ '' ] ifNotNil: [ :parentNode | parentNode sourceText ] ]
 ]
 
-{ #category : #'*FAST-Java-Model-Extension' }
+{ #category : '*FAST-Java-Model-Extension' }
 FASTJavaMethodEntity >> statements [
 	^ self statementBlock ifNotNil: [ :existingStatementBlock | existingStatementBlock statements ] ifNil: [ OrderedCollection new ]
 ]

--- a/src/FAST-Java-Model-Extension/FASTJavaModifier.extension.st
+++ b/src/FAST-Java-Model-Extension/FASTJavaModifier.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaModifier }
+Extension { #name : 'FASTJavaModifier' }
 
-{ #category : #'*FAST-Java-Model-Extension' }
+{ #category : '*FAST-Java-Model-Extension' }
 FASTJavaModifier >> mooseNameOn: aStream [
 	token
 		ifNil: [ super mooseNameOn: aStream ]

--- a/src/FAST-Java-Model-Extension/FASTJavaPackageDeclaration.extension.st
+++ b/src/FAST-Java-Model-Extension/FASTJavaPackageDeclaration.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaPackageDeclaration }
+Extension { #name : 'FASTJavaPackageDeclaration' }
 
-{ #category : #'*FAST-Java-Model-Extension' }
+{ #category : '*FAST-Java-Model-Extension' }
 FASTJavaPackageDeclaration >> declarationName [
 
 	self
@@ -10,7 +10,7 @@ FASTJavaPackageDeclaration >> declarationName [
 	^ self qualifiedName
 ]
 
-{ #category : #'*FAST-Java-Model-Extension' }
+{ #category : '*FAST-Java-Model-Extension' }
 FASTJavaPackageDeclaration >> declarationName: aName [
 
 	self

--- a/src/FAST-Java-Model-Extension/FASTJavaQualifiedName.extension.st
+++ b/src/FAST-Java-Model-Extension/FASTJavaQualifiedName.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaQualifiedName }
+Extension { #name : 'FASTJavaQualifiedName' }
 
-{ #category : #'*FAST-Java-Model-Extension' }
+{ #category : '*FAST-Java-Model-Extension' }
 FASTJavaQualifiedName >> fullName [
 
 	^ String streamContents: [ :stream | 

--- a/src/FAST-Java-Model-Extension/FASTJavaQualifiedTypeName.extension.st
+++ b/src/FAST-Java-Model-Extension/FASTJavaQualifiedTypeName.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaQualifiedTypeName }
+Extension { #name : 'FASTJavaQualifiedTypeName' }
 
-{ #category : #'*FAST-Java-Model-Extension' }
+{ #category : '*FAST-Java-Model-Extension' }
 FASTJavaQualifiedTypeName >> fullName [
 	^ self namespace fullName , '.', self name
 ]

--- a/src/FAST-Java-Model-Extension/FASTJavaTypeName.extension.st
+++ b/src/FAST-Java-Model-Extension/FASTJavaTypeName.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #FASTJavaTypeName }
+Extension { #name : 'FASTJavaTypeName' }
 
-{ #category : #'*FAST-Java-Model-Extension' }
+{ #category : '*FAST-Java-Model-Extension' }
 FASTJavaTypeName >> fullName [
 	^ name
 ]

--- a/src/FAST-Java-Model-Extension/MooseAbstractGroup.extension.st
+++ b/src/FAST-Java-Model-Extension/MooseAbstractGroup.extension.st
@@ -1,20 +1,20 @@
-Extension { #name : #MooseAbstractGroup }
+Extension { #name : 'MooseAbstractGroup' }
 
-{ #category : #'*FAST-Java-Model-Extension' }
+{ #category : '*FAST-Java-Model-Extension' }
 MooseAbstractGroup >> allFASTJavaClassDeclaration [
 	<navigation: 'All FASTJava class declarations'>
 	<package: #FAST>
 	^ self allWithType: FASTJavaClassDeclaration
 ]
 
-{ #category : #'*FAST-Java-Model-Extension' }
+{ #category : '*FAST-Java-Model-Extension' }
 MooseAbstractGroup >> allFASTJavaIdentifier [
 	<navigation: 'All FASTJava identifiers'>
 	<package: #FAST>
 	^ self allWithType: FASTJavaIdentifier
 ]
 
-{ #category : #'*FAST-Java-Model-Extension' }
+{ #category : '*FAST-Java-Model-Extension' }
 MooseAbstractGroup >> allFASTJavaMethodEntity [
 	<navigation: 'All FASTJava method entities'>
 	<package: #FAST>

--- a/src/FAST-Java-Model-Extension/package.st
+++ b/src/FAST-Java-Model-Extension/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'FAST-Java-Model-Extension' }
+Package { #name : 'FAST-Java-Model-Extension' }

--- a/src/FAST-Java-Model-Generator/FASTJavaMetamodelGenerator.class.st
+++ b/src/FAST-Java-Model-Generator/FASTJavaMetamodelGenerator.class.st
@@ -1112,6 +1112,8 @@ FASTJavaMetamodelGenerator >> defineHierarchy [
 	javaTypePattern --|> tExpression.
 
 	compilationUnit --|> tEntity.
+	compilationUnit --|> #THasImmediateSource.
+	compilationUnit withPrecedenceOf: #THasImmediateSource.
 
 	"package and import do not use TDeclaration on purpose: they are only contained in a compilation unit"
 	packageDeclaration --|> tEntity.

--- a/src/FAST-Java-Model/FASTJavaCompilationUnit.class.st
+++ b/src/FAST-Java-Model/FASTJavaCompilationUnit.class.st
@@ -13,6 +13,11 @@ I represent a compilation unit, I can contain declarations for a package, import
 | `interfaceDeclarations` | `FASTJavaCompilationUnit` | `compilationUnit` | `FASTJavaInterfaceDeclaration` | My interface declarations|
 | `packageDeclaration` | `FASTJavaCompilationUnit` | `compilationUnit` | `FASTJavaPackageDeclaration` | My package declaration, or nil for the default package|
 
+### Other
+| Relation | Origin | Opposite | Type | Comment |
+|---|
+| `element` | `FamixTSourceAnchor` | `sourceAnchor` | `FamixTSourceEntity` | Enable the accessibility to the famix entity that this class is a source pointer for|
+
 
 ## Properties
 ======================
@@ -20,20 +25,21 @@ I represent a compilation unit, I can contain declarations for a package, import
 | Name | Type | Default value | Comment |
 |---|
 | `endPos` | `Number` | nil | |
+| `source` | `String` | nil | Actual source code of the source entity|
 | `startPos` | `Number` | nil | |
 
 "
 Class {
 	#name : 'FASTJavaCompilationUnit',
 	#superclass : 'FASTJavaEntity',
-	#traits : 'FASTTEntity',
-	#classTraits : 'FASTTEntity classTrait',
+	#traits : '(FASTTEntity + FamixTHasImmediateSource withPrecedenceOf: FamixTHasImmediateSource)',
+	#classTraits : '(FASTTEntity classTrait + FamixTHasImmediateSource classTrait withPrecedenceOf: FamixTHasImmediateSource classTrait)',
 	#instVars : [
-		'#packageDeclaration => FMOne type: #FASTJavaPackageDeclaration opposite: #compilationUnit',
-		'#importDeclarations => FMMany type: #FASTJavaImportDeclaration opposite: #compilationUnit',
 		'#classDeclarations => FMMany type: #FASTJavaClassDeclaration opposite: #compilationUnit',
+		'#enumDeclarations => FMMany type: #FASTJavaEnumDeclaration opposite: #compilationUnit',
+		'#importDeclarations => FMMany type: #FASTJavaImportDeclaration opposite: #compilationUnit',
 		'#interfaceDeclarations => FMMany type: #FASTJavaInterfaceDeclaration opposite: #compilationUnit',
-		'#enumDeclarations => FMMany type: #FASTJavaEnumDeclaration opposite: #compilationUnit'
+		'#packageDeclaration => FMOne type: #FASTJavaPackageDeclaration opposite: #compilationUnit'
 	],
 	#category : 'FAST-Java-Model-Entities',
 	#package : 'FAST-Java-Model',

--- a/src/FAST-Java-Model/FASTJavaImportDeclaration.class.st
+++ b/src/FAST-Java-Model/FASTJavaImportDeclaration.class.st
@@ -32,9 +32,9 @@ Class {
 	#traits : 'FASTJavaTWithQualifiedName + FASTTEntity',
 	#classTraits : 'FASTJavaTWithQualifiedName classTrait + FASTTEntity classTrait',
 	#instVars : [
-		'#isStatic => FMProperty defaultValue: false',
+		'#compilationUnit => FMOne type: #FASTJavaCompilationUnit opposite: #importDeclarations',
 		'#isOnDemand => FMProperty defaultValue: false',
-		'#compilationUnit => FMOne type: #FASTJavaCompilationUnit opposite: #importDeclarations'
+		'#isStatic => FMProperty defaultValue: false'
 	],
 	#category : 'FAST-Java-Model-Entities',
 	#package : 'FAST-Java-Model',

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCAbstractMethodTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCAbstractMethodTest.class.st
@@ -12,17 +12,6 @@ JavaSmaCCAbstractMethodTest >> abstractMethod [
 }'
 ]
 
-{ #category : 'accessing' }
-JavaSmaCCAbstractMethodTest >> javaMethod [
-	^ self shouldBeImplemented
-]
-
-{ #category : 'running' }
-JavaSmaCCAbstractMethodTest >> parseExpressionString: aString [
-
-	^ JavaSmaCCProgramNodeImporterVisitor new getExpressionAST: aString
-]
-
 { #category : 'running' }
 JavaSmaCCAbstractMethodTest >> setUp [
 

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCClassImporterAbstractTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCClassImporterAbstractTest.class.st
@@ -5,6 +5,12 @@ Class {
 	#package : 'FAST-Java-SmaCC-Importer-Tests'
 }
 
+{ #category : 'testing' }
+JavaSmaCCClassImporterAbstractTest class >> isAbstract [
+
+	^ self == JavaSmaCCClassImporterAbstractTest
+]
+
 { #category : 'running' }
 JavaSmaCCClassImporterAbstractTest >> javaClass [
 

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCCommentsAbstractTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCCommentsAbstractTest.class.st
@@ -5,6 +5,12 @@ Class {
 	#package : 'FAST-Java-SmaCC-Importer-Tests'
 }
 
+{ #category : 'testing' }
+JavaSmaCCCommentsAbstractTest class >> isAbstract [
+
+	^ self == JavaSmaCCCommentsAbstractTest
+]
+
 { #category : 'parsing' }
 JavaSmaCCCommentsAbstractTest >> parseMethodString: aString [
 	"overriding to add comments to the parser"

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCImporterAbstractTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCImporterAbstractTest.class.st
@@ -9,6 +9,12 @@ Class {
 	#package : 'FAST-Java-SmaCC-Importer-Tests'
 }
 
+{ #category : 'testing' }
+JavaSmaCCImporterAbstractTest class >> isAbstract [
+
+	^ self == JavaSmaCCImporterAbstractTest
+]
+
 { #category : 'running' }
 JavaSmaCCImporterAbstractTest >> parseClassString: aString [
 	^ JavaSmaCCProgramNodeImporterVisitor new parseCodeString: aString

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCMethodImporterAbstractTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCMethodImporterAbstractTest.class.st
@@ -5,6 +5,12 @@ Class {
 	#package : 'FAST-Java-SmaCC-Importer-Tests'
 }
 
+{ #category : 'testing' }
+JavaSmaCCMethodImporterAbstractTest class >> isAbstract [
+
+	^ self == JavaSmaCCMethodImporterAbstractTest
+]
+
 { #category : 'running' }
 JavaSmaCCMethodImporterAbstractTest >> javaMethod [
 	self subclassResponsibility 

--- a/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCSourceTest.class.st
+++ b/src/FAST-Java-SmaCC-Importer-Tests/JavaSmaCCSourceTest.class.st
@@ -7,36 +7,466 @@ Class {
 
 { #category : 'tests' }
 JavaSmaCCSourceTest >> javaClass [
-	^ 'class A {
-	void hello() {
-		int i = 0;
-	}
-}' 
+	^ String streamContents: [ :s |
+		s << 'class A {'.
+		s cr tab << self javaMethod.
+		s cr << '}' ]
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> javaClassWithInitializer [
+	^ String streamContents: [ :s |
+		s << 'class A {'.
+		s cr tab << self javaInitializer.
+		s cr << '}' ]
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> javaClassWithInnerClass [
+	^ String streamContents: [ :s |
+		s << 'class Outer {'.
+		s cr tab << self javaInnerClass.
+		s cr << '}' ]
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> javaCompilationUnit [
+	^ String streamContents: [ :s |
+		s << self javaPackageDeclaration.
+		s cr << self javaImportDeclaration.
+		s cr << self javaClass ]
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> javaCompilationUnitWithEnum [
+	^ String streamContents: [ :s |
+		s << self javaPackageDeclaration.
+		s cr << self javaEnum ]
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> javaCompilationUnitWithInitializer [
+	^ String streamContents: [ :s |
+		s << self javaPackageDeclaration.
+		s cr << self javaClassWithInitializer ]
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> javaCompilationUnitWithInnerClass [
+	^ String streamContents: [ :s |
+		s << self javaPackageDeclaration.
+		s cr << self javaClassWithInnerClass ]
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> javaCompilationUnitWithInterface [
+	^ String streamContents: [ :s |
+		s << self javaPackageDeclaration.
+		s cr << self javaInterface ]
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> javaEnum [
+	^ 'enum E {}'
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> javaImportDeclaration [
+	^ 'import com.Example;'
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> javaInitializer [
+	^ '{}'
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> javaInnerClass [
+	^ String streamContents: [ :s |
+		s << 'class Inner {'.
+		s cr tab tab << self javaMethodOfInnerClass.
+		s cr tab << '}' ]
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> javaInterface [
+	^ 'interface I {}'
 ]
 
 { #category : 'tests' }
 JavaSmaCCSourceTest >> javaMethod [
-	^ 'void hello() {
-	int i = 0;
-}' 
+	^ String streamContents: [ :s |
+		s << 'void hello() {'.
+		s cr tab tab << 'int i = 0;'.
+		s cr tab << '}' ]
 ]
 
 { #category : 'tests' }
-JavaSmaCCSourceTest >> testAccessToClassSourceText [
-
-	fastModel := self parseClassString: self javaClass.
-
-	self assert: (fastModel allWithType: FASTJavaMethodEntity) anyOne sourceText equals: self javaClass.
-	self assert: (fastModel allWithType: FASTJavaClassDeclaration) anyOne sourceText equals: self javaClass.
-	self assert: (fastModel allWithType: FASTJavaMethodEntity) anyOne sourceCode equals: 'void hello() {
-		int i = 0;
-	}'
+JavaSmaCCSourceTest >> javaMethodOfInnerClass [
+	^ 'void inner() {}'
 ]
 
 { #category : 'tests' }
-JavaSmaCCSourceTest >> testAccessToMethodSourceText [
+JavaSmaCCSourceTest >> javaPackageDeclaration [
+	^ 'package org.moose;'
+]
 
-	fastModel := self parseMethodString: self javaMethod.
-	
-	self assert: (fastModel allWithType: FASTJavaMethodEntity) anyOne sourceText equals: self javaMethod
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testClassSourceCode [
+
+	| sourceText |
+	sourceText := self javaClass.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaClassDeclaration) anyOne sourceCode equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testClassSourceCodeInCompilationUnit [
+
+	| sourceText |
+	sourceText := self javaCompilationUnit.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaClassDeclaration) anyOne sourceCode equals: self javaClass
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testClassSourceText [
+
+	| sourceText |
+	sourceText := self javaClass.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaClassDeclaration) anyOne sourceText equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testClassSourceTextInCompilationUnit [
+
+	| sourceText |
+	sourceText := self javaCompilationUnit.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaClassDeclaration) anyOne sourceText equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testCompilationUnitSourceCode [
+
+	| sourceText |
+	sourceText := self javaCompilationUnit.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaCompilationUnit) anyOne sourceCode equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testCompilationUnitSourceText [
+
+	| sourceText |
+	sourceText := self javaCompilationUnit.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaCompilationUnit) anyOne sourceText equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testEnumSourceCode [
+
+	| sourceText |
+	sourceText := self javaEnum.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaEnumDeclaration) anyOne sourceCode equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testEnumSourceCodeInCompilationUnit [
+
+	| sourceText |
+	sourceText := self javaCompilationUnitWithEnum.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaEnumDeclaration) anyOne sourceCode equals: self javaEnum
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testEnumSourceText [
+
+	| sourceText |
+	sourceText := self javaEnum.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaEnumDeclaration) anyOne sourceText equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testEnumSourceTextInCompilationUnit [
+
+	| sourceText |
+	sourceText := self javaCompilationUnitWithEnum.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaEnumDeclaration) anyOne sourceText equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testImportDeclarationSourceCode [
+
+	| sourceText |
+	sourceText := self javaCompilationUnit.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaImportDeclaration) anyOne sourceCode equals: self javaImportDeclaration
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testImportDeclarationSourceText [
+
+	| sourceText |
+	sourceText := self javaCompilationUnit.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaImportDeclaration) anyOne sourceText equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testInitializerSourceCode [
+
+	| sourceText |
+	sourceText := self javaInitializer.
+	fastModel := self parseMethodString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaInitializer) anyOne sourceCode equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testInitializerSourceCodeInClass [
+
+	| sourceText |
+	sourceText := self javaClassWithInitializer.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaInitializer) anyOne sourceCode equals: self javaInitializer
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testInitializerSourceCodeInCompilationUnit [
+
+	| sourceText |
+	sourceText := self javaCompilationUnitWithInitializer.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaInitializer) anyOne sourceCode equals: self javaInitializer
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testInitializerSourceText [
+
+	| sourceText |
+	sourceText := self javaInitializer.
+	fastModel := self parseMethodString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaInitializer) anyOne sourceText equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testInitializerSourceTextInClass [
+
+	| sourceText |
+	sourceText := self javaClassWithInitializer.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaInitializer) anyOne sourceText equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testInitializerSourceTextInCompilationUnit [
+
+	| sourceText |
+	sourceText := self javaCompilationUnitWithInitializer.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaInitializer) anyOne sourceText equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testInnerClassSourceCodeInClass [
+
+	| sourceText |
+	sourceText := self javaClassWithInnerClass.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaClassDeclaration) second sourceCode equals: self javaInnerClass
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testInnerClassSourceCodeInCompilationUnit [
+
+	| sourceText |
+	sourceText := self javaCompilationUnitWithInnerClass.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaClassDeclaration) second sourceCode equals: self javaInnerClass
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testInnerClassSourceTextInClass [
+
+	| sourceText |
+	sourceText := self javaClassWithInnerClass.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaClassDeclaration) second sourceText equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testInnerClassSourceTextInCompilationUnit [
+
+	| sourceText |
+	sourceText := self javaCompilationUnitWithInnerClass.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaClassDeclaration) second sourceText equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testInterfaceSourceCode [
+
+	| sourceText |
+	sourceText := self javaInterface.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaInterfaceDeclaration) anyOne sourceCode equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testInterfaceSourceCodeInCompilationUnit [
+
+	| sourceText |
+	sourceText := self javaCompilationUnitWithInterface.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaInterfaceDeclaration) anyOne sourceCode equals: self javaInterface
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testInterfaceSourceText [
+
+	| sourceText |
+	sourceText := self javaInterface.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaInterfaceDeclaration) anyOne sourceText equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testInterfaceSourceTextInCompilationUnit [
+
+	| sourceText |
+	sourceText := self javaCompilationUnitWithInterface.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaInterfaceDeclaration) anyOne sourceText equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testMethodOfInnerClassSourceCode [
+
+	| sourceText |
+	sourceText := self javaCompilationUnitWithInnerClass.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaMethodEntity) anyOne sourceCode equals: self javaMethodOfInnerClass
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testMethodOfInnerClassSourceText [
+
+	| sourceText |
+	sourceText := self javaCompilationUnitWithInnerClass.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaMethodEntity) anyOne sourceText equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testMethodSourceCode [
+
+	| sourceText |
+	sourceText := self javaMethod.
+	fastModel := self parseMethodString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaMethodEntity) anyOne sourceCode equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testMethodSourceCodeInClass [
+
+	| sourceText |
+	sourceText := self javaClass.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaMethodEntity) anyOne sourceCode equals: self javaMethod
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testMethodSourceCodeInCompilationUnit [
+
+	| sourceText |
+	sourceText := self javaCompilationUnit.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaMethodEntity) anyOne sourceCode equals: self javaMethod
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testMethodSourceText [
+
+	| sourceText |
+	sourceText := self javaMethod.
+	fastModel := self parseMethodString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaMethodEntity) anyOne sourceText equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testMethodSourceTextInClass [
+
+	| sourceText |
+	sourceText := self javaClass.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaMethodEntity) anyOne sourceText equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testMethodSourceTextInCompilationUnit [
+
+	| sourceText |
+	sourceText := self javaCompilationUnit.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaMethodEntity) anyOne sourceText equals: sourceText
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testPackageDeclarationSourceCode [
+
+	| sourceText |
+	sourceText := self javaCompilationUnit.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaPackageDeclaration) anyOne sourceCode equals: self javaPackageDeclaration
+]
+
+{ #category : 'tests' }
+JavaSmaCCSourceTest >> testPackageDeclarationSourceText [
+
+	| sourceText |
+	sourceText := self javaCompilationUnit.
+	fastModel := self parseClassString: sourceText.
+
+	self assert: (fastModel allWithType: FASTJavaPackageDeclaration) anyOne sourceText equals: sourceText
 ]

--- a/src/FAST-Java-SmaCC-Importer/JavaSmaCCProgramNodeImporterVisitor.class.st
+++ b/src/FAST-Java-SmaCC-Importer/JavaSmaCCProgramNodeImporterVisitor.class.st
@@ -270,11 +270,12 @@ JavaSmaCCProgramNodeImporterVisitor >> parseCodeString: aCodeString [
 	[
 	self accept: ast.
 	((self model allWithSubTypesOfAny: {
+			  FASTJavaCompilationUnit.
 			  FASTJavaClassDeclaration.
 			  FASTJavaInterfaceDeclaration.
 			  FASTJavaEnumDeclaration }) detect: [ :classDeclaration |
 		 classDeclaration parentNode isNil ]) source:
-		ast completeSource asString ]
+			ast completeSource asString ]
 		on: Error
 		do: [ :err |
 			('FAST Err parsing: ' , String crlf , aCodeString) record.
@@ -1070,9 +1071,9 @@ JavaSmaCCProgramNodeImporterVisitor >> visitNewClass: aNewClass [
 	aNewClass expressions do: [ :expression | 
 		currentFASTEntity arguments add: (self clone accept: expression) ].
 	aNewClass type
-		ifNotNil: [ 
+		ifNotNil: [
 		currentFASTEntity type: (self clone accept: aNewClass type) ]
-		ifNil: [ 
+		ifNil: [
 			currentFASTEntity type: (self clone createTypeName: aNewClass name).
 			currentFASTEntity receiver: (self clone accept: aNewClass primary) ].
 	aNewClass declarations do: [ :method | 
@@ -1105,6 +1106,7 @@ JavaSmaCCProgramNodeImporterVisitor >> visitPackageDeclaration: aPackageDeclarat
 	currentFASTEntity := self addToModel: FASTJavaPackageDeclaration new.
 	self setStartEndPos: aPackageDeclaration.
 	currentFASTEntity qualifiedName: (self clone accept: aPackageDeclaration name).
+	^ currentFASTEntity
 ]
 
 { #category : 'visitor' }
@@ -1171,6 +1173,21 @@ JavaSmaCCProgramNodeImporterVisitor >> visitPrimitiveType: aPrimitiveType [
 	^ currentFASTEntity
 ]
 
+{ #category : 'generated' }
+JavaSmaCCProgramNodeImporterVisitor >> visitProgramFile: aProgramFile [
+	currentFASTEntity := self addToModel: FASTJavaCompilationUnit new.
+	self setStartEndPos: aProgramFile.
+	currentFASTEntity packageDeclaration: (self clone accept: aProgramFile packageDeclaration).
+	aProgramFile imports do: [ :import | currentFASTEntity addImportDeclaration: (self clone accept: import) ].
+	aProgramFile typeDeclarations do: [ :declaration | "Maybe CompilationUnit should use TWithDeclarations rather than having a relation for classes, interfaces, and enums"
+			| entity |
+			entity := self clone accept: declaration.
+			entity isClassDeclaration ifTrue: [ currentFASTEntity addClassDeclaration: entity ].
+			entity isInterfaceDeclaration ifTrue: [ currentFASTEntity addInterfaceDeclaration: entity ].
+			entity isEnumDeclaration ifTrue: [ currentFASTEntity addEnumDeclaration: entity ] ].
+	^ currentFASTEntity
+]
+
 { #category : 'visitor' }
 JavaSmaCCProgramNodeImporterVisitor >> visitQualifiedName: aQualifiedName [
 
@@ -1222,6 +1239,7 @@ JavaSmaCCProgramNodeImporterVisitor >> visitSingleTypeImportDeclaration: aSingle
 	currentFASTEntity := self addToModel: FASTJavaImportDeclaration new.
 	self setStartEndPos: aSingleTypeImportDeclaration.
 	currentFASTEntity qualifiedName: (self clone accept: aSingleTypeImportDeclaration name).
+	^ currentFASTEntity
 ]
 
 { #category : 'visitor' }
@@ -1271,7 +1289,7 @@ JavaSmaCCProgramNodeImporterVisitor >> visitSuperConstructorInvocation: aSuperCo
 JavaSmaCCProgramNodeImporterVisitor >> visitSuperMemberAcessor: aFieldAccess [
 	currentFASTEntity := self create: FASTJavaVariableExpression from: aFieldAccess superToken.
 	currentFASTEntity name: aFieldAccess superToken value.
-	^currentFASTEntity 
+	^ currentFASTEntity 
 ]
 
 { #category : 'visitor' }
@@ -1371,13 +1389,13 @@ JavaSmaCCProgramNodeImporterVisitor >> visitTypeArgument: aTypeArgument [
 
 { #category : 'visitor' }
 JavaSmaCCProgramNodeImporterVisitor >> visitTypeImportOnDemandDeclaration: aTypeImportOnDemandDeclaration [
-
 	currentFASTEntity := self addToModel: FASTJavaImportDeclaration new.
 	self setStartEndPos: aTypeImportOnDemandDeclaration.
 	currentFASTEntity
 		isOnDemand: true;
 		qualifiedName:
-			(self clone accept: aTypeImportOnDemandDeclaration name)
+			(self clone accept: aTypeImportOnDemandDeclaration name).
+	^ currentFASTEntity
 ]
 
 { #category : 'visitor' }
@@ -1395,7 +1413,7 @@ JavaSmaCCProgramNodeImporterVisitor >> visitTypeParameter: aTypeParameter [
 	currentFASTEntity name: aTypeParameter name value.
 	aTypeParameter types do: [ :type |
 		currentFASTEntity addType: (self clone accept: type)
-		 ].
+	].
 	^ currentFASTEntity
 ]
 


### PR DESCRIPTION
Fixes #263

Reusing `FamixTHasImmediateSource` from Famix is practical, but the contract doesn't hold for FAST: only the root entity has the source.
This fix is a bit of a shim: we override `sourceText` on entities that use the trait to lookup on parent when it doesn't have the source.

Some unfortunate Tonel noise in FAST-Java-Model-Extension package...